### PR TITLE
quarkus.dev.instrumentation renamed to quarkus.live-reload.instrumentation

### DIFF
--- a/src/main/resources/META-INF/rewrite/quarkus-upgrade.yml
+++ b/src/main/resources/META-INF/rewrite/quarkus-upgrade.yml
@@ -35,3 +35,6 @@ recipeList:
   - org.openrewrite.java.ChangeMethodName:
       methodPattern: io.smallrye.mutiny.groups.MultiTransform byTakingFirstItems(..)
       newMethodName: first
+  - org.openrewrite.properties.ChangePropertyKey:
+      oldPropertyKey: quarkus.dev.instrumentation
+      newPropertyKey: quarkus.live-reload.instrumentation


### PR DESCRIPTION
closes https://github.com/openrewrite/rewrite-quarkus/issues/2

