### PR TITLE
Quarkus 2.x migration recipes placeholder

### DIFF
--- a/src/main/resources/META-INF/rewrite/quarkus-upgrade.yml
+++ b/src/main/resources/META-INF/rewrite/quarkus-upgrade.yml
@@ -38,3 +38,15 @@ recipeList:
   - org.openrewrite.properties.ChangePropertyKey:
       oldPropertyKey: quarkus.dev.instrumentation
       newPropertyKey: quarkus.live-reload.instrumentation
+---
+type: specs.openrewrite.org/v1beta/recipe
+name: org.openrewrite.java.quarkus.Quarkus1to2Migration
+displayName: Quarkus 2.x migration from Quarkus 1.x
+description: Migrates Quarkus 1.x to 2.x.
+recipeList:
+  - org.openrewrite.properties.ChangePropertyKey:
+      oldPropertyKey: smallrye.jwt.sign.key-location
+      newPropertyKey: smallrye.jwt.sign.key.location
+  - org.openrewrite.properties.ChangePropertyKey:
+      oldPropertyKey: smallrye.jwt.encrypt.key-location
+      newPropertyKey: smallrye.jwt.encrypt.key.location


### PR DESCRIPTION
Putting a 2.x migration placeholder out there for the benefit of any recipes falling under the 2.x migration guide https://github.com/quarkusio/quarkus/wiki/Migration-Guide-2.0

Once this is in place it'll pave way to put https://github.com/quarkusio/quarkus/wiki/Migration-Guide-2.0 migrations in place, esp. straightforward recipes like property key migrations

closes https://github.com/openrewrite/rewrite-quarkus/issues/13