### PR TITLE
Quarkus 2.x changes `@io.quarkus.grpc.runtime.annotations.GrpcService` to `@io.quarkus.grpc.GrpcClient`

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -106,6 +106,7 @@ dependencies {
     testRuntimeOnly("org.openrewrite:rewrite-java-11:${rewriteVersion}")
     testRuntimeOnly("org.openrewrite:rewrite-java-8:${rewriteVersion}")
 
+    testRuntimeOnly("io.quarkus:quarkus-grpc:1.13.4.Final")
     testRuntimeOnly("io.smallrye.reactive:mutiny:0.12.+")
 }
 

--- a/src/main/java/org/openrewrite/java/quarkus/quarkus2/GrpcServiceAnnotationToGrpcClient.java
+++ b/src/main/java/org/openrewrite/java/quarkus/quarkus2/GrpcServiceAnnotationToGrpcClient.java
@@ -1,0 +1,102 @@
+/*
+ * Copyright 2020 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.java.quarkus.quarkus2;
+
+import org.openrewrite.Cursor;
+import org.openrewrite.ExecutionContext;
+import org.openrewrite.Recipe;
+import org.openrewrite.TreeVisitor;
+import org.openrewrite.internal.ListUtils;
+import org.openrewrite.java.ChangeType;
+import org.openrewrite.java.JavaIsoVisitor;
+import org.openrewrite.java.search.UsesType;
+import org.openrewrite.java.tree.J;
+import org.openrewrite.java.tree.TypeUtils;
+
+public class GrpcServiceAnnotationToGrpcClient extends Recipe {
+    private static final String GRPC_SERVICE_ANNOTATION_FQN = "io.quarkus.grpc.runtime.annotations.GrpcService";
+    private static final String GRPC_CLIENT_ANNOTATION_FQN = "io.quarkus.grpc.GrpcClient";
+
+    @Override
+    public String getDisplayName() {
+        return "Migrate `@GrpcService` To `@GrpcClient`";
+    }
+
+    @Override
+    public String getDescription() {
+        return "Migrate the `@GrpcService` annotation to `@GrpcClient`. Removes the optional `@GrpcClient.value()` unless the service name is different from the name of annotated element.";
+    }
+
+    @Override
+    protected TreeVisitor<?, ExecutionContext> getSingleSourceApplicableTest() {
+        return new UsesType<>(GRPC_SERVICE_ANNOTATION_FQN);
+    }
+
+    @Override
+    protected TreeVisitor<?, ExecutionContext> getVisitor() {
+        return new GrpcServiceToGrpcClientAnnotationVisitor();
+    }
+
+    private static class GrpcServiceToGrpcClientAnnotationVisitor extends JavaIsoVisitor<ExecutionContext> {
+        private static boolean shouldRemoveArgument(J.VariableDeclarations.NamedVariable namedVariable, J.Literal assignValue) {
+            Object value = assignValue.getValue();
+            assert value != null;
+            return namedVariable.getSimpleName().equals(value);
+        }
+
+        @Override
+        public J.CompilationUnit visitCompilationUnit(J.CompilationUnit cu, ExecutionContext ctx) {
+            doAfterVisit(new ChangeType(GRPC_SERVICE_ANNOTATION_FQN, GRPC_CLIENT_ANNOTATION_FQN));
+            return super.visitCompilationUnit(cu, ctx);
+        }
+
+        @Override
+        public J.Annotation visitAnnotation(J.Annotation annotation, ExecutionContext ctx) {
+            J.Annotation a = super.visitAnnotation(annotation, ctx);
+            if (TypeUtils.isOfClassType(annotation.getType(), GRPC_SERVICE_ANNOTATION_FQN) &&
+                    a.getArguments() != null &&
+                    getCursor().getParentOrThrow().getValue() instanceof J.VariableDeclarations) {
+
+                a = a.withArguments(ListUtils.map(a.getArguments(), arg -> {
+                    Cursor varDecsCursor = getCursor().getParentOrThrow();
+                    J.VariableDeclarations.NamedVariable namedVariable = varDecsCursor.<J.VariableDeclarations>getValue().getVariables().get(0);
+                    if (arg instanceof J.Assignment) {
+                        J.Assignment assignment = (J.Assignment) arg;
+                        if (assignment.getVariable() instanceof J.Identifier && assignment.getAssignment() instanceof J.Literal) {
+                            J.Identifier assignName = (J.Identifier) assignment.getVariable();
+                            if (assignName.getSimpleName().equals("value")) {
+                                if (shouldRemoveArgument(namedVariable, (J.Literal) assignment.getAssignment())) {
+                                    return null;
+                                }
+                            }
+                        }
+                    } else if (arg instanceof J.Literal) {
+                        if (shouldRemoveArgument(namedVariable, (J.Literal) arg)) {
+                            return null;
+                        }
+                    }
+
+                    return arg;
+                }));
+            }
+
+            return a;
+        }
+
+    }
+
+}
+

--- a/src/main/java/org/openrewrite/java/quarkus/quarkus2/package-info.java
+++ b/src/main/java/org/openrewrite/java/quarkus/quarkus2/package-info.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright 2020 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+@NonNullApi
+@NonNullFields
+package org.openrewrite.java.quarkus.quarkus2;
+
+import org.openrewrite.internal.lang.NonNullApi;
+import org.openrewrite.internal.lang.NonNullFields;

--- a/src/main/resources/META-INF/rewrite/quarkus-upgrade.yml
+++ b/src/main/resources/META-INF/rewrite/quarkus-upgrade.yml
@@ -69,3 +69,4 @@ recipeList:
       propertyKey: quarkus.quartz.store-type
       oldValue: db
       newValue: jdbc-cmt
+  - org.openrewrite.java.quarkus.quarkus2.GrpcServiceAnnotationToGrpcClient

--- a/src/test/kotlin/org/openrewrite/java/quarkus/quarkus2/GrpcServiceAnnotationToGrpcClientTest.kt
+++ b/src/test/kotlin/org/openrewrite/java/quarkus/quarkus2/GrpcServiceAnnotationToGrpcClientTest.kt
@@ -1,0 +1,100 @@
+/*
+ * Copyright 2020 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.java.quarkus.quarkus2
+
+import org.junit.jupiter.api.Test
+import org.openrewrite.Recipe
+import org.openrewrite.java.JavaParser
+import org.openrewrite.java.JavaRecipeTest
+
+class GrpcServiceAnnotationToGrpcClientTest : JavaRecipeTest {
+    override val parser: JavaParser = JavaParser.fromJavaVersion()
+        .logCompilationWarningsAndErrors(false)
+        .classpath("quarkus-grpc", "inject-api")
+        .build()
+
+    override val recipe: Recipe
+        get() = GrpcServiceAnnotationToGrpcClient()
+
+    companion object {
+        private const val greeterBlockingStub: String = """
+            package org.openrewrite.example;
+
+            public class GreeterGrpc {
+                public class GreeterBlockingStub {
+                }
+            }
+        """
+    }
+
+    @Test
+    fun grpcServiceAnnotationToGrpcClient() = assertChanged(
+        dependsOn = arrayOf(greeterBlockingStub),
+        before = """
+            package org.openrewrite.example;
+
+            import io.quarkus.grpc.runtime.annotations.GrpcService;
+            import javax.inject.Inject;
+
+            public class ExampleResource {
+                @Inject
+                @GrpcService("client")
+                GreeterGrpc.GreeterBlockingStub client;
+            }
+        """,
+        after = """
+            package org.openrewrite.example;
+
+            import io.quarkus.grpc.GrpcClient;
+            import javax.inject.Inject;
+
+            public class ExampleResource {
+                @Inject
+                @GrpcClient
+                GreeterGrpc.GreeterBlockingStub client;
+            }
+        """
+    )
+
+    @Test
+    fun keepValueArgumentIfNameDiffersFromFieldName() = assertChanged(
+        dependsOn = arrayOf(greeterBlockingStub),
+        before = """
+            package org.openrewrite.example;
+
+            import io.quarkus.grpc.runtime.annotations.GrpcService;
+            import javax.inject.Inject;
+
+            public class ExampleResource {
+                @Inject
+                @GrpcService("hello-service")
+                GreeterGrpc.GreeterBlockingStub client;
+            }
+        """,
+        after = """
+            package org.openrewrite.example;
+
+            import io.quarkus.grpc.GrpcClient;
+            import javax.inject.Inject;
+
+            public class ExampleResource {
+                @Inject
+                @GrpcClient("hello-service")
+                GreeterGrpc.GreeterBlockingStub client;
+            }
+        """
+    )
+}

--- a/src/test/kotlin/org/openrewrite/java/quarkus/quarkus2/package-info.java
+++ b/src/test/kotlin/org/openrewrite/java/quarkus/quarkus2/package-info.java
@@ -1,0 +1,16 @@
+/*
+ * Copyright 2020 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.java.quarkus.quarkus2;


### PR DESCRIPTION
Quarkus 2.x changes `@io.quarkus.grpc.runtime.annotations.GrpcService` to `@io.quarkus.grpc.GrpcClient`

see: https://github.com/quarkusio/quarkus/wiki/Migration-Guide-2.0#grpc
see: https://quarkus.io/guides/grpc-service-consumption

>The io.quarkus.grpc.runtime.annotations.GrpcService annotation was renamed to io.quarkus.grpc.GrpcClient. Furthermore, the @GrpcClient.value() is optional and the service name can be derived from the annotated element.

Please note, this PR puts `quarkus2` recipes into their own package, and there's no reason that it _has_ to be this way. I'm not sure if it's the best thing to do, I just put it there for organizing. Feedback is happily welcome on whether to remove it.