### PR TITLE
Mutiny `multi.transform().hotStream()` to `multi.hotStream()` recipe

### DIFF
--- a/src/main/java/org/openrewrite/java/quarkus/MultiTransformHotStreamToMultiHotStream.java
+++ b/src/main/java/org/openrewrite/java/quarkus/MultiTransformHotStreamToMultiHotStream.java
@@ -1,0 +1,52 @@
+package org.openrewrite.java.quarkus;
+
+import org.openrewrite.ExecutionContext;
+import org.openrewrite.Recipe;
+import org.openrewrite.TreeVisitor;
+import org.openrewrite.internal.lang.Nullable;
+import org.openrewrite.java.JavaIsoVisitor;
+import org.openrewrite.java.MethodMatcher;
+import org.openrewrite.java.search.UsesMethod;
+import org.openrewrite.java.tree.J;
+
+public class MultiTransformHotStreamToMultiHotStream extends Recipe {
+
+    private static final MethodMatcher hotStreamMethodMatcher = new MethodMatcher("io.smallrye.mutiny.groups.MultiTransform toHotStream()");
+
+    @Override
+    public String getDisplayName() {
+        return "Mutiny `multi.transform().hotStream()` to `multi.hotStream()`.";
+    }
+
+    @Override
+    public String getDescription() {
+        return "Replace deprecated Mutiny `multi.transform().toHotStream()` with `multi.toHotStream()`.";
+    }
+
+    @Override
+    protected @Nullable TreeVisitor<?, ExecutionContext> getSingleSourceApplicableTest() {
+        return new UsesMethod<>(hotStreamMethodMatcher);
+    }
+
+    @Override
+    protected TreeVisitor<?, ExecutionContext> getVisitor() {
+        return new JavaIsoVisitor<ExecutionContext>() {
+            final MethodMatcher transformMethodMatcher = new MethodMatcher("io.smallrye.mutiny.Multi transform()");
+            final MethodMatcher selectMethodMatcher = new MethodMatcher("io.smallrye.mutiny.Multi select()");
+
+            @Override
+            public J.MethodInvocation visitMethodInvocation(J.MethodInvocation method, ExecutionContext executionContext) {
+                J.MethodInvocation mi = super.visitMethodInvocation(method, executionContext);
+                if (hotStreamMethodMatcher.matches(mi)) {
+                    if (mi.getSelect() != null && mi.getSelect() instanceof J.MethodInvocation) {
+                        J.MethodInvocation mSelect = (J.MethodInvocation)mi.getSelect();
+                        if (transformMethodMatcher.matches(mSelect) || selectMethodMatcher.matches(mSelect)) {
+                            return mi.withSelect(mSelect.getSelect());
+                        }
+                    }
+                }
+                return mi;
+            }
+        };
+    }
+}

--- a/src/main/resources/META-INF/rewrite/quarkus-upgrade.yml
+++ b/src/main/resources/META-INF/rewrite/quarkus-upgrade.yml
@@ -23,6 +23,7 @@ recipeList:
       groupId: io.quarkus
       artifactId: quarkus-universe-bom
       newVersion: 1.13.x
+  - org.openrewrite.java.quarkus.MultiTransformHotStreamToMultiHotStream
   - org.openrewrite.java.ChangeMethodName:
       methodPattern: io.smallrye.mutiny.Multi collectItems()
       newMethodName: collect

--- a/src/test/kotlin/org/openrewrite/java/quarkus/MultiTransformHotStreamToMultiHotStreamTest.kt
+++ b/src/test/kotlin/org/openrewrite/java/quarkus/MultiTransformHotStreamToMultiHotStreamTest.kt
@@ -1,0 +1,45 @@
+package org.openrewrite.java.quarkus
+
+import org.junit.jupiter.api.Test
+import org.openrewrite.Recipe
+import org.openrewrite.java.JavaParser
+import org.openrewrite.java.JavaRecipeTest
+
+class MultiTransformHotStreamToMultiHotStreamTest : JavaRecipeTest {
+    override val parser: JavaParser = JavaParser.fromJavaVersion()
+        .logCompilationWarningsAndErrors(false)
+        .classpath("mutiny", "reactive-streams")
+        .build()
+
+    override val recipe: Recipe
+        get() = MultiTransformHotStreamToMultiHotStream()
+
+    @Test
+    fun replaceTransform() = assertChanged(
+        before = """
+            import io.smallrye.mutiny.Multi;
+            import java.util.List;
+            import java.time.Duration;
+            public class A {
+                public MultiCollect<Long> hotStreamGreetings(int count, String name) {
+                    return Multi.createFrom().ticks().every(Duration.ofMillis(1))
+                            .transform()
+                            .toHotStream()
+                            .collect();
+                }
+            }
+        """,
+        after = """
+            import io.smallrye.mutiny.Multi;
+            import java.util.List;
+            import java.time.Duration;
+            public class A {
+                public MultiCollect<Long> hotStreamGreetings(int count, String name) {
+                    return Multi.createFrom().ticks().every(Duration.ofMillis(1))
+                            .toHotStream()
+                            .collect();
+                }
+            }
+        """
+    )
+}


### PR DESCRIPTION
Mutiny `multi.transform().hotStream()` to `multi.hotStream()` recipe. Fixes #20