### PR TITLE
Convert Quarkus `@ConfigProperties` annotated interfaces to Smallrye `@ConfigMapping` configuration

### DIFF
--- a/src/main/java/org/openrewrite/java/quarkus/ConfigPropertiesToConfigMapping.java
+++ b/src/main/java/org/openrewrite/java/quarkus/ConfigPropertiesToConfigMapping.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2020 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.java.quarkus;
+
+import org.openrewrite.ExecutionContext;
+import org.openrewrite.Recipe;
+import org.openrewrite.TreeVisitor;
+import org.openrewrite.internal.lang.Nullable;
+import org.openrewrite.java.AnnotationMatcher;
+import org.openrewrite.java.ChangeType;
+import org.openrewrite.java.JavaIsoVisitor;
+import org.openrewrite.java.search.UsesType;
+import org.openrewrite.java.tree.J;
+
+public class ConfigPropertiesToConfigMapping extends Recipe {
+    @Override
+    public String getDisplayName() {
+        return "Migrate `@ConfigProperties` To `@ConfigMapping`";
+    }
+
+    @Override
+    public String getDescription() {
+        return "Migrate the Quarkus `@ConfigProperties` annotated configurations to the equivalent Smallrye `@ConfigMapping`.";
+    }
+
+    @Override
+    protected @Nullable TreeVisitor<?, ExecutionContext> getApplicableTest() {
+        return new UsesType<>("io.quarkus.arc.config.ConfigProperties");
+    }
+
+    @Override
+    protected TreeVisitor<?, ExecutionContext> getVisitor() {
+        return new JavaIsoVisitor<ExecutionContext>() {
+            final AnnotationMatcher CONFIG_PROPERTIES_ANNOTATION_MATCHER = new AnnotationMatcher("@io.quarkus.arc.config.ConfigProperties");
+
+            @Override
+            public J.ClassDeclaration visitClassDeclaration(J.ClassDeclaration classDecl, ExecutionContext executionContext) {
+                J.ClassDeclaration cd = super.visitClassDeclaration(classDecl, executionContext);
+                if (cd.getLeadingAnnotations().stream().anyMatch(CONFIG_PROPERTIES_ANNOTATION_MATCHER::matches)
+                        && cd.getKind().equals(J.ClassDeclaration.Kind.Type.Interface)) {
+                    doAfterVisit(new ChangeType("io.quarkus.arc.config.ConfigProperties", "io.smallrye.config.ConfigMapping"));
+                }
+                return cd;
+            }
+        };
+    }
+}

--- a/src/main/resources/META-INF/rewrite/quarkus-upgrade.yml
+++ b/src/main/resources/META-INF/rewrite/quarkus-upgrade.yml
@@ -23,6 +23,7 @@ recipeList:
       groupId: io.quarkus
       artifactId: quarkus-universe-bom
       newVersion: 1.13.x
+  - org.openrewrite.java.quarkus.ConfigPropertiesToConfigMapping
   - org.openrewrite.java.quarkus.MultiTransformHotStreamToMultiHotStream
   - org.openrewrite.java.ChangeMethodName:
       methodPattern: io.smallrye.mutiny.Multi collectItems()

--- a/src/test/kotlin/org/openrewrite/java/quarkus/ConfigPropertiesToConfigMappingTest.kt
+++ b/src/test/kotlin/org/openrewrite/java/quarkus/ConfigPropertiesToConfigMappingTest.kt
@@ -1,0 +1,79 @@
+/*
+ * Copyright 2020 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.java.quarkus
+
+import org.junit.jupiter.api.Disabled
+import org.junit.jupiter.api.Test
+import org.openrewrite.Issue
+import org.openrewrite.Recipe
+import org.openrewrite.java.JavaParser
+import org.openrewrite.java.JavaRecipeTest
+
+class ConfigPropertiesToConfigMappingTest : JavaRecipeTest {
+    override val parser: JavaParser = JavaParser.fromJavaVersion()
+        .logCompilationWarningsAndErrors(false)
+        .classpath("quarkus-arc")
+        .build()
+
+    override val recipe: Recipe
+        get() = ConfigPropertiesToConfigMapping()
+
+    @Test
+    fun migrateAnnotatedInterfaces() = assertChanged(
+        before = """
+            import io.quarkus.arc.config.ConfigProperties;
+
+            @ConfigProperties(prefix = "greeting")
+            public interface MyConfiguration {
+                String message();
+                String name();
+            }
+        """,
+        after = """
+            import io.smallrye.config.ConfigMapping;
+
+            @ConfigMapping(prefix = "greeting")
+            public interface MyConfiguration {
+                String message();
+                String name();
+            }
+        """
+    )
+
+    @Issue("https://github.com/openrewrite/rewrite-quarkus/issues/24")
+    @Disabled
+    @Test
+    fun changeConfigClassType() = assertChanged(
+        before = """
+            import io.quarkus.arc.config.ConfigProperties;
+
+            @ConfigProperties(prefix = "greeting")
+            public class MyConfiguration {
+                String message;
+                String name;
+            }
+        """,
+        after = """
+            import io.smallrye.config.ConfigMapping;
+
+            @ConfigMapping(prefix = "greeting")
+            public interface MyConfiguration {
+                String message();
+                String name();
+            }
+        """
+    )
+}


### PR DESCRIPTION
 Convert Quarkus `@ConfigProperties` annotated interfaces to Smallrye `@ConifgMapping`. Fixes #15