### PR TITLE
Remove `avro-maven-plugin` as part of Quarkus 2.0 migration

### DIFF
--- a/src/main/resources/META-INF/rewrite/quarkus-upgrade.yml
+++ b/src/main/resources/META-INF/rewrite/quarkus-upgrade.yml
@@ -80,3 +80,6 @@ recipeList:
   - org.openrewrite.java.ChangeType:
       oldFullyQualifiedTypeName: io.quarkus.qute.api.ResourcePath
       newFullyQualifiedTypeName: io.quarkus.qute.Location
+  - org.openrewrite.maven.RemovePlugin:
+      groupId: org.apache.avro
+      artifactId: avro-maven-plugin


### PR DESCRIPTION
see: https://github.com/quarkusio/quarkus/wiki/Migration-Guide-2.0#avro

closes https://github.com/openrewrite/rewrite-quarkus/issues/16