### PR TITLE
Conditionally remove the `avro-maven-plugin` based on whether the `quarkus-plugin` is found

### DIFF
--- a/src/main/java/org/openrewrite/java/quarkus/quarkus2/RemoveAvroMavenPlugin.java
+++ b/src/main/java/org/openrewrite/java/quarkus/quarkus2/RemoveAvroMavenPlugin.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2020 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.java.quarkus.quarkus2;
+
+import org.openrewrite.ExecutionContext;
+import org.openrewrite.Recipe;
+import org.openrewrite.TreeVisitor;
+import org.openrewrite.internal.lang.Nullable;
+import org.openrewrite.maven.MavenVisitor;
+import org.openrewrite.maven.RemovePlugin;
+import org.openrewrite.maven.search.FindPlugin;
+import org.openrewrite.maven.tree.Maven;
+import org.openrewrite.xml.marker.XmlSearchResult;
+
+public class RemoveAvroMavenPlugin extends Recipe {
+    @Override
+    public String getDisplayName() {
+        return "Remove `avro-maven-plugin`";
+    }
+
+    @Override
+    public String getDescription() {
+        return "Removes the `avro-maven-plugin` if the `quarkus-maven-plugin` is found in the project's `pom.xml`. Avro has been integrated with the Quarkus code generation mechanism. This replaces the need to use the Avro plugin.";
+    }
+
+    @Override
+    protected @Nullable TreeVisitor<?, ExecutionContext> getApplicableTest() {
+        return new MavenVisitor() {
+            @Override
+            public Maven visitMaven(Maven maven, ExecutionContext ctx) {
+                if (!FindPlugin.find(maven, "io.quarkus", "quarkus-maven-plugin").isEmpty()) {
+                    maven = maven.withMarkers(maven.getMarkers().addIfAbsent(new XmlSearchResult(RemoveAvroMavenPlugin.this)));
+                }
+                return super.visitMaven(maven, ctx);
+            }
+        };
+    }
+
+    @Override
+    protected TreeVisitor<?, ExecutionContext> getVisitor() {
+        return new RemoveAvroMavenPluginVisitor();
+    }
+
+    private static class RemoveAvroMavenPluginVisitor extends MavenVisitor {
+        @Override
+        public Maven visitMaven(Maven maven, ExecutionContext ctx) {
+            doAfterVisit(new RemovePlugin("org.apache.avro", "avro-maven-plugin"));
+            return super.visitMaven(maven, ctx);
+        }
+    }
+
+}
+

--- a/src/main/resources/META-INF/rewrite/quarkus-upgrade.yml
+++ b/src/main/resources/META-INF/rewrite/quarkus-upgrade.yml
@@ -80,6 +80,4 @@ recipeList:
   - org.openrewrite.java.ChangeType:
       oldFullyQualifiedTypeName: io.quarkus.qute.api.ResourcePath
       newFullyQualifiedTypeName: io.quarkus.qute.Location
-  - org.openrewrite.maven.RemovePlugin:
-      groupId: org.apache.avro
-      artifactId: avro-maven-plugin
+  - org.openrewrite.java.quarkus.quarkus2.RemoveAvroMavenPlugin


### PR DESCRIPTION
closes https://github.com/openrewrite/rewrite-quarkus/issues/30

Changes this recipe so `avro-maven-plugin` will only be removed if the `quarkus-maven-plugin` is also found as a `plugin` within the same `pom.xml`