### PR TITLE
Upgrade versions of quarkus-maven-plugin

### DIFF
--- a/src/main/resources/META-INF/rewrite/quarkus-upgrade.yml
+++ b/src/main/resources/META-INF/rewrite/quarkus-upgrade.yml
@@ -23,6 +23,10 @@ recipeList:
       groupId: io.quarkus
       artifactId: quarkus-universe-bom
       newVersion: 1.13.x
+  - org.openrewrite.maven.UpgradePluginVersion:
+      groupId: io.quarkus
+      artifactId: quarkus-maven-plugin
+      newVersion: 1.13.x
   - org.openrewrite.java.quarkus.ConfigPropertiesToConfigMapping
   - org.openrewrite.java.quarkus.MultiTransformHotStreamToMultiHotStream
   - org.openrewrite.java.quarkus.MigrateQuarkusMavenPluginNativeImageGoal
@@ -81,3 +85,7 @@ recipeList:
       oldFullyQualifiedTypeName: io.quarkus.qute.api.ResourcePath
       newFullyQualifiedTypeName: io.quarkus.qute.Location
   - org.openrewrite.java.quarkus.quarkus2.RemoveAvroMavenPlugin
+  - org.openrewrite.maven.UpgradePluginVersion:
+      groupId: io.quarkus
+      artifactId: quarkus-maven-plugin
+      newVersion: 2.x


### PR DESCRIPTION
closes https://github.com/openrewrite/rewrite-quarkus/issues/6

Upgrades quarkus maven plugins for both 1.13.x and placeholder for 2.x in the 2.x upgrade composite.

(do keep in mind, though, that until quarkus maven plugin 2.0.0.Final is released, 2.0.0.CRX is not going to show up.)