### PR TITLE
Move quarkus 2.x migration recipe to the quarkus2 category

### DIFF
--- a/src/main/resources/META-INF/rewrite/category.yml
+++ b/src/main/resources/META-INF/rewrite/category.yml
@@ -22,4 +22,3 @@ description: Recipes for upgrading and patching [Quarkus](https://quarkus.io/) a
 type: specs.openrewrite.org/v1beta/category
 name: Quarkus 2.x
 packageName: org.openrewrite.java.quarkus.quarkus2
-

--- a/src/main/resources/META-INF/rewrite/quarkus-upgrade.yml
+++ b/src/main/resources/META-INF/rewrite/quarkus-upgrade.yml
@@ -57,7 +57,7 @@ recipeList:
       newPropertyKey: quarkus.live-reload.instrumentation
 ---
 type: specs.openrewrite.org/v1beta/recipe
-name: org.openrewrite.java.quarkus.Quarkus1to2Migration
+name: org.openrewrite.java.quarkus.quarkus2.Quarkus1to2Migration
 displayName: Quarkus 2.x migration from Quarkus 1.x
 description: Migrates Quarkus 1.x to 2.x.
 recipeList:


### PR DESCRIPTION
In order to improve the recipe categorization layout in the UI, move the `Quarkus1to2Migration` recipe to the `quarkus2` package/category.