### PR TITLE
support bumping quarkus-bom

### DIFF
--- a/src/main/resources/META-INF/rewrite/quarkus.yml
+++ b/src/main/resources/META-INF/rewrite/quarkus.yml
@@ -18,10 +18,13 @@ name: org.openrewrite.java.quarkus.Quarkus1to1_13Migration
 displayName: Quarkus 1.13 migration from Quarkus 1.11
 description: Migrates Quarkus 1.11 to 1.13.
 recipeList:
-# (https://github.com/openrewrite/rewrite-quarkus/issues/37) fixme
 #  - org.openrewrite.maven.UpgradeDependencyVersion:
 #      groupId: io.quarkus
 #      artifactId: quarkus-universe-bom
+#      newVersion: 1.13.x
+#  - org.openrewrite.maven.UpgradeDependencyVersion:
+#      groupId: io.quarkus
+#      artifactId: quarkus-bom
 #      newVersion: 1.13.x
 #  - org.openrewrite.maven.UpgradePluginVersion:
 #      groupId: io.quarkus
@@ -113,6 +116,10 @@ recipeList:
   - org.openrewrite.maven.UpgradeDependencyVersion:
       groupId: io.quarkus
       artifactId: quarkus-universe-bom
+      newVersion: 2.x
+  - org.openrewrite.maven.UpgradeDependencyVersion:
+      groupId: io.quarkus
+      artifactId: quarkus-bom
       newVersion: 2.x
   - org.openrewrite.maven.UpgradePluginVersion:
       groupId: io.quarkus


### PR DESCRIPTION
in case the quarkus-core bom is used specifically vs. using quarkus-universe-bom (which appears to be used more often)-- but, just using quarkus-bom is done as well 

- https://stackoverflow.com/questions/59880235/how-to-update-the-quarkus-version-used
- https://github.com/quarkusio/quarkus-quickstarts/blob/3c35a1dd3b6a8740d3103ba8a79c2d9ab3caf795/getting-started/pom.xml#L11
- https://groups.google.com/g/quarkus-dev/c/tKGYE5biVt4