### PR TITLE
Upgrade Maven parent and Gradle dependencies

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -25,11 +25,11 @@ dependencies {
     implementation("org.openrewrite:rewrite-maven:${rewriteVersion}")
     implementation("org.openrewrite:rewrite-properties:${rewriteVersion}")
 
+    implementation("org.openrewrite.recipe:rewrite-java-dependencies:${rewriteVersion}")
+
     runtimeOnly("org.openrewrite:rewrite-java-17:${rewriteVersion}")
 
     testImplementation("org.openrewrite:rewrite-test:${rewriteVersion}")
-    testImplementation("org.openrewrite:rewrite-maven:${rewriteVersion}")
-    testImplementation("org.openrewrite:rewrite-properties:${rewriteVersion}")
     testImplementation("org.openrewrite:rewrite-java-tck:${rewriteVersion}")
 
     testImplementation("javax.xml.ws:jaxws-api:2.3.1")

--- a/src/main/resources/META-INF/rewrite/quarkus.yml
+++ b/src/main/resources/META-INF/rewrite/quarkus.yml
@@ -117,11 +117,19 @@ recipeList:
   - org.openrewrite.java.ChangeType:
       oldFullyQualifiedTypeName: io.quarkus.mongodb.runtime.MongoClientName
       newFullyQualifiedTypeName: io.quarkus.mongodb.MongoClientName
-  - org.openrewrite.maven.UpgradeDependencyVersion:
+  - org.openrewrite.maven.ChangeParentPom:
+      oldGroupId: io.quarkus
+      oldArtifactId: quarkus-universe-bom
+      newVersion: 2.x
+  - org.openrewrite.java.dependencies.UpgradeDependencyVersion:
       groupId: io.quarkus
       artifactId: quarkus-universe-bom
       newVersion: 2.x
-  - org.openrewrite.maven.UpgradeDependencyVersion:
+  - org.openrewrite.maven.ChangeParentPom:
+      oldGroupId: io.quarkus
+      oldArtifactId: quarkus-bom
+      newVersion: 2.x
+  - org.openrewrite.java.dependencies.UpgradeDependencyVersion:
       groupId: io.quarkus
       artifactId: quarkus-bom
       newVersion: 2.x

--- a/src/test/java/org/openrewrite/quarkus/quarkus2/Quarkus1to2MigrationTest.java
+++ b/src/test/java/org/openrewrite/quarkus/quarkus2/Quarkus1to2MigrationTest.java
@@ -17,15 +17,15 @@ package org.openrewrite.quarkus.quarkus2;
 
 import org.junit.jupiter.api.Test;
 import org.openrewrite.DocumentExample;
-import org.openrewrite.config.Environment;
 import org.openrewrite.java.JavaParser;
 import org.openrewrite.test.RecipeSpec;
 import org.openrewrite.test.RewriteTest;
 
 import static org.openrewrite.java.Assertions.java;
+import static org.openrewrite.maven.Assertions.pomXml;
 
 class Quarkus1to2MigrationTest implements RewriteTest {
-
+    @Override
     public void defaults(RecipeSpec spec) {
         spec.parser(JavaParser.fromJavaVersion()
             .logCompilationWarningsAndErrors(true)
@@ -33,17 +33,14 @@ class Quarkus1to2MigrationTest implements RewriteTest {
               "quarkus-qute", "qute-core", "mongodb-driver-core",
               "quarkus-mongodb-client", "mongodb-driver-sync", "inject-api"
             ))
-          .recipe(Environment.builder()
-            .scanRuntimeClasspath("org.openrewrite.quarkus.quarkus2")
-            .build()
-            .activateRecipes("org.openrewrite.quarkus.quarkus2.Quarkus1to2Migration")
-          );
+          .recipeFromResource("/META-INF/rewrite/quarkus.yml","org.openrewrite.quarkus.quarkus2.Quarkus1to2Migration");
     }
 
     @DocumentExample
     @Test
     void quteResourcePathToLocation() {
         rewriteRun(
+          //language=java
           java(
             """
               import io.quarkus.qute.api.ResourcePath;
@@ -83,6 +80,7 @@ class Quarkus1to2MigrationTest implements RewriteTest {
     @Test
     void changeQuteCheckedTemplate() {
         rewriteRun(
+          //language=java
           java(
             """
               import io.quarkus.qute.TemplateInstance;
@@ -110,6 +108,7 @@ class Quarkus1to2MigrationTest implements RewriteTest {
     @Test
     void migrateQuarkusMongoClientName() {
         rewriteRun(
+          //language=java
           java(
             """
               import com.mongodb.client.MongoClient;
@@ -134,6 +133,83 @@ class Quarkus1to2MigrationTest implements RewriteTest {
                   @MongoClientName("clientName")
                   MongoClient mongoClient;
               }
+              """
+          )
+        );
+    }
+
+
+    @Test
+    void upgradeQuarkusUniverseBom() {
+        // XXX Does not work yet when scope is import; needs a fix upstream
+        rewriteRun(
+          //language=XML
+          pomXml(
+            """
+              <project>
+                <modelVersion>4.0.0</modelVersion>
+                <groupId>org.openrewrite.example</groupId>
+                <artifactId>my-app</artifactId>
+                <version>1</version>
+                <dependencies>
+                  <dependency>
+                    <groupId>io.quarkus</groupId>
+                    <artifactId>quarkus-bom</artifactId>
+                    <version>1.13.7.Final</version>
+                  </dependency>
+                </dependencies>
+              </project>
+              """,
+            """
+              <project>
+                <modelVersion>4.0.0</modelVersion>
+                <groupId>org.openrewrite.example</groupId>
+                <artifactId>my-app</artifactId>
+                <version>1</version>
+                <dependencies>
+                  <dependency>
+                    <groupId>io.quarkus</groupId>
+                    <artifactId>quarkus-bom</artifactId>
+                    <version>2.16.12.Final</version>
+                  </dependency>
+                </dependencies>
+              </project>
+              """
+          )
+        );
+    }
+    @Test
+    void upgradeQuarkusUniverseParent() {
+        rewriteRun(
+          //language=XML
+          pomXml(
+            """
+              <project>
+                <modelVersion>4.0.0</modelVersion>
+                <parent>
+                  <groupId>io.quarkus</groupId>
+                  <artifactId>quarkus-universe-bom</artifactId>
+                  <version>1.13.7.Final</version>
+                  <relativePath />
+                </parent>
+                <groupId>org.openrewrite.example</groupId>
+                <artifactId>my-app</artifactId>
+                <version>1</version>
+              </project>
+              """,
+            """
+              <project>
+                <modelVersion>4.0.0</modelVersion>
+                <parent>
+                  <groupId>io.quarkus</groupId>
+                  <artifactId>quarkus-universe-bom</artifactId>
+                  <version>2.16.12.Final</version>
+                  <relativePath />
+                </parent>
+                <groupId>org.openrewrite.example</groupId>
+                <artifactId>my-app</artifactId>
+                <version>1</version>
+              </project>
               """
           )
         );

--- a/src/test/java/org/openrewrite/quarkus/quarkus2/Quarkus1to2MigrationTest.java
+++ b/src/test/java/org/openrewrite/quarkus/quarkus2/Quarkus1to2MigrationTest.java
@@ -141,7 +141,6 @@ class Quarkus1to2MigrationTest implements RewriteTest {
 
     @Test
     void upgradeQuarkusUniverseBom() {
-        // XXX Does not work yet when scope is import; needs a fix upstream
         rewriteRun(
           //language=XML
           pomXml(
@@ -151,13 +150,17 @@ class Quarkus1to2MigrationTest implements RewriteTest {
                 <groupId>org.openrewrite.example</groupId>
                 <artifactId>my-app</artifactId>
                 <version>1</version>
-                <dependencies>
-                  <dependency>
-                    <groupId>io.quarkus</groupId>
-                    <artifactId>quarkus-bom</artifactId>
-                    <version>1.13.7.Final</version>
-                  </dependency>
-                </dependencies>
+                <dependencyManagement>
+                  <dependencies>
+                    <dependency>
+                      <groupId>io.quarkus</groupId>
+                      <artifactId>quarkus-bom</artifactId>
+                      <version>1.13.7.Final</version>
+                      <type>pom</type>
+                      <scope>import</scope>
+                    </dependency>
+                  </dependencies>
+                </dependencyManagement>
               </project>
               """,
             """
@@ -166,13 +169,17 @@ class Quarkus1to2MigrationTest implements RewriteTest {
                 <groupId>org.openrewrite.example</groupId>
                 <artifactId>my-app</artifactId>
                 <version>1</version>
-                <dependencies>
-                  <dependency>
-                    <groupId>io.quarkus</groupId>
-                    <artifactId>quarkus-bom</artifactId>
-                    <version>2.16.12.Final</version>
-                  </dependency>
-                </dependencies>
+                <dependencyManagement>
+                  <dependencies>
+                    <dependency>
+                      <groupId>io.quarkus</groupId>
+                      <artifactId>quarkus-bom</artifactId>
+                      <version>2.16.12.Final</version>
+                      <type>pom</type>
+                      <scope>import</scope>
+                    </dependency>
+                  </dependencies>
+                </dependencyManagement>
               </project>
               """
           )


### PR DESCRIPTION
## What's changed?
- Depend on `rewrite-java-dependencies`
- Add `ChangeParentPom`
- Add tests for dependency upgrades: surface not updated `import` scope dependencies

## What's your motivation?
Fixes #66
For consistency with other projects & predictable placement in release train.

## Any additional context
- #66