### PR TITLE
Find profiles and properties and change property keys

### DIFF
--- a/src/main/java/org/openrewrite/quarkus/ChangeQuarkusPropertyKey.java
+++ b/src/main/java/org/openrewrite/quarkus/ChangeQuarkusPropertyKey.java
@@ -17,11 +17,7 @@ package org.openrewrite.quarkus;
 
 import lombok.EqualsAndHashCode;
 import lombok.Value;
-import org.openrewrite.ExecutionContext;
-import org.openrewrite.Option;
-import org.openrewrite.Preconditions;
-import org.openrewrite.Recipe;
-import org.openrewrite.TreeVisitor;
+import org.openrewrite.*;
 import org.openrewrite.internal.lang.Nullable;
 import org.openrewrite.quarkus.search.FindQuarkusProperties;
 

--- a/src/main/java/org/openrewrite/quarkus/ChangeQuarkusPropertyKey.java
+++ b/src/main/java/org/openrewrite/quarkus/ChangeQuarkusPropertyKey.java
@@ -45,7 +45,7 @@ public class ChangeQuarkusPropertyKey extends Recipe {
     List<String> except;
 
     @Option(displayName = "Profile",
-            description = "The profile where the property is defined. If not specified, the property will be changed on the default profile.",
+            description = "The profile where the property is defined. If not specified, the property will be changed on all profiles. Defaults to `true`.",
             required = false,
             example = "dev")
     @Nullable

--- a/src/main/java/org/openrewrite/quarkus/ChangeQuarkusPropertyKey.java
+++ b/src/main/java/org/openrewrite/quarkus/ChangeQuarkusPropertyKey.java
@@ -1,0 +1,92 @@
+/*
+ * Copyright 2023 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.quarkus;
+
+import lombok.EqualsAndHashCode;
+import lombok.Value;
+import org.openrewrite.ExecutionContext;
+import org.openrewrite.Option;
+import org.openrewrite.Preconditions;
+import org.openrewrite.Recipe;
+import org.openrewrite.TreeVisitor;
+import org.openrewrite.internal.lang.Nullable;
+import org.openrewrite.quarkus.search.FindQuarkusProperties;
+
+import java.util.List;
+
+@Value
+@EqualsAndHashCode(callSuper = true)
+public class ChangeQuarkusPropertyKey extends Recipe {
+
+    @Option(displayName = "Old property key",
+            description = "The property key to rename. Supports regex.",
+            example = "quarkus.hibernate-search-orm.automatic-indexing.synchronization.strategy")
+    String oldPropertyKey;
+
+    @Option(displayName = "New property key",
+            description = "The new name for the property key. Supports regex.",
+            example = "quarkus.hibernate-search-orm.indexing.plan.synchronization.strategy")
+    String newPropertyKey;
+
+    @Option(displayName = "Except",
+            description = "Regex. If any of these property keys exist as direct children of `oldPropertyKey`, then they will not be moved to `newPropertyKey`.",
+            required = false)
+    @Nullable
+    List<String> except;
+
+    @Option(displayName = "Profile",
+            description = "The profile where the property is defined. If not specified, the property will be changed on the default profile.",
+            required = false,
+            example = "dev")
+    @Nullable
+    String profile;
+
+    @Option(displayName = "Change for all Profiles",
+            description = "If set, thr property will be changed on all available profiles.",
+            required = false,
+            example = "false")
+    @Nullable
+    Boolean changeAllProfiles;
+
+    @Option(displayName = "Optional list of file path matcher",
+            description = "Each value in this list represents a glob expression that is used to match which files will " +
+                          "be modified. If this value is not present, this recipe will query the execution context for " +
+                          "reasonable defaults. (\"**/application.yml\", \"**/application.yaml\", " +
+                          "\"**/application.properties\" and \"**/META-INF/microprofile-config.properties\".",
+            required = false,
+            example = "[\"**/application.yaml\"]")
+    @Nullable
+    List<String> pathExpressions;
+
+    @Override
+    public String getDisplayName() {
+        return "Change Quarkus property key";
+    }
+
+    @Override
+    public String getDescription() {
+        return "Change a Quarkus property key.";
+    }
+
+    @Override
+    public TreeVisitor<?, ExecutionContext> getVisitor() {
+        return Preconditions.check(
+                new FindQuarkusProperties(oldPropertyKey, profile, changeAllProfiles).getVisitor(),
+                new ChangeQuarkusPropertyKeyVisitor(oldPropertyKey, newPropertyKey, except, profile, changeAllProfiles, pathExpressions)
+        );
+    }
+}
+

--- a/src/main/java/org/openrewrite/quarkus/ChangeQuarkusPropertyKeyVisitor.java
+++ b/src/main/java/org/openrewrite/quarkus/ChangeQuarkusPropertyKeyVisitor.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2023 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.openrewrite.quarkus;
 
 import lombok.RequiredArgsConstructor;

--- a/src/main/java/org/openrewrite/quarkus/ChangeQuarkusPropertyKeyVisitor.java
+++ b/src/main/java/org/openrewrite/quarkus/ChangeQuarkusPropertyKeyVisitor.java
@@ -198,7 +198,7 @@ class ChangeQuarkusPropertyKeyVisitor extends TreeVisitor<Tree, ExecutionContext
                     .append(System.lineSeparator());
             indent = indent + "  ";
         }
-        for (int i = 0; i < propertyParts.length; i++ ) {
+        for (int i = 0; i < propertyParts.length; i++) {
             String part = propertyParts[i];
             if (i > 0 && yaml.length() > 0) {
                 yaml.append(System.lineSeparator());

--- a/src/main/java/org/openrewrite/quarkus/ChangeQuarkusPropertyKeyVisitor.java
+++ b/src/main/java/org/openrewrite/quarkus/ChangeQuarkusPropertyKeyVisitor.java
@@ -1,0 +1,187 @@
+package org.openrewrite.quarkus;
+
+import lombok.RequiredArgsConstructor;
+import org.openrewrite.ExecutionContext;
+import org.openrewrite.Tree;
+import org.openrewrite.TreeVisitor;
+import org.openrewrite.internal.lang.Nullable;
+import org.openrewrite.properties.PropertiesVisitor;
+import org.openrewrite.properties.tree.Properties;
+import org.openrewrite.quarkus.search.FindQuarkusProfiles;
+import org.openrewrite.yaml.tree.Yaml;
+
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Set;
+import java.util.TreeSet;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+@RequiredArgsConstructor
+class ChangeQuarkusPropertyKeyVisitor extends TreeVisitor<Tree, ExecutionContext> {
+
+    final String oldPropertyKey;
+
+    final String newPropertyKey;
+
+    @Nullable
+    final List<String> except;
+
+    @Nullable
+    final String profile;
+
+    @Nullable
+    final Boolean changeAllProfiles;
+
+    @Nullable
+    final List<String> pathExpressions;
+
+    @Override
+    public @Nullable Tree visit(@Nullable Tree tree, ExecutionContext ctx) {
+        if (tree instanceof Properties.File) {
+            return visitPropertiesFile(tree, ctx);
+        } else if (tree instanceof Yaml.Documents) {
+            return visitYamlDocuments(tree, ctx);
+        }
+        return tree;
+    }
+
+    private @Nullable Tree visitPropertiesFile(Tree tree, ExecutionContext ctx) {
+        boolean changeAllProfiles = Boolean.TRUE.equals(this.changeAllProfiles);
+        if ((this.profile == null && this.changeAllProfiles == null) || changeAllProfiles) {
+            String oldPropertyKey = changeAllProfiles ? "^(.*?)" + this.oldPropertyKey : this.oldPropertyKey;
+            String newPropertyKey = changeAllProfiles ? "$1" + fixRegexReferences(this.newPropertyKey) : this.newPropertyKey;
+            tree = new org.openrewrite.properties.ChangePropertyKey(oldPropertyKey, newPropertyKey, false, true)
+                    .getVisitor()
+                    .visit(tree, ctx);
+        } else if (profile != null) {
+            // Make changes to a property on a single profile
+            Set<String> profiles = FindQuarkusProfiles.find(tree);
+            if (profiles.size() == 1 && profiles.contains(profile)) {
+                tree = new org.openrewrite.properties.ChangePropertyKey(oldPropertyKey, newPropertyKey, false, true)
+                        .getVisitor()
+                        .visit(tree, ctx);
+            } else {
+                Set<Properties.Entry> entries = new TreeSet<>(Comparator.comparing(Properties.Entry::getKey));
+                Pattern pattern = Pattern.compile(oldPropertyKey);
+                new PropertiesVisitor<Set<Properties.Entry>>() {
+                    @Override
+                    public Properties visitEntry(Properties.Entry entry, Set<Properties.Entry> ps) {
+                        if (pattern.matcher(entry.getKey()).find()) {
+                            ps.add(entry);
+                        }
+                        return super.visitEntry(entry, ps);
+                    }
+                }.visit(tree, entries);
+
+                for (Properties.Entry entry : entries) {
+                    String oldKey = entry.getKey();
+                    if (oldKey.charAt(0) != '%' || !oldKey.contains(profile)) {
+                        continue;
+                    }
+
+                    List<String> remainingProfiles = new ArrayList<>(entries.size());
+                    for (String profile : oldKey.substring(1, oldKey.indexOf('.')).split(",")) {
+                        if (!profile.equals(this.profile)) {
+                            remainingProfiles.add(profile);
+                        }
+                    }
+
+                    String propertySuffix = getPropertySuffix(oldKey);
+
+                    // Remove the old property
+                    tree = new org.openrewrite.properties.DeleteProperty(oldKey, false)
+                            .getVisitor()
+                            .visit(tree, ctx);
+
+                    // Add the new property for the named profile
+                    String newKey = "%" + profile + "." + transformString(oldPropertyKey, newPropertyKey, propertySuffix);
+                    newKey = fixRegexReferences(newKey);
+                    tree = new org.openrewrite.properties.AddProperty(
+                            newKey,
+                            entry.getValue().getText(),
+                            null,
+                            entry.getDelimiter().getCharacter().toString()
+                    ).getVisitor().visit(tree, ctx);
+
+                    if (!remainingProfiles.isEmpty()) {
+                        // Add the new property for the named profile
+                        tree = new org.openrewrite.properties.AddProperty(
+                                "%" + String.join(",", remainingProfiles) + "." + propertySuffix,
+                                entry.getValue().getText(),
+                                null,
+                                entry.getDelimiter().getCharacter().toString()
+                        ).getVisitor().visit(tree, ctx);
+                    }
+                }
+            }
+        }
+        return tree;
+    }
+
+    private @Nullable Tree visitYamlDocuments(Tree tree, ExecutionContext ctx) {
+        String oldPropertyKey = this.oldPropertyKey;
+        String newPropertyKey = this.newPropertyKey;
+        boolean changeAllProfiles = Boolean.TRUE.equals(this.changeAllProfiles);
+        if ((this.profile == null && this.changeAllProfiles == null) || changeAllProfiles) {
+            if (changeAllProfiles) {
+                oldPropertyKey = "^(.*)" + oldPropertyKey;
+                newPropertyKey = fixRegexReferences(this.newPropertyKey);
+            }
+            tree = new org.openrewrite.yaml.ChangePropertyKey(oldPropertyKey, newPropertyKey, true, except)
+                    .getVisitor()
+                    .visit(tree, ctx);
+        } else if (profile != null) {
+            // Make changes to a property on a single profile
+            // test if key exists in a single profile;
+            // if not remove the profile from the key and add a new entry containing the other profiles with the current key value
+            throw new UnsupportedOperationException("TODO");
+        }
+        return tree;
+    }
+
+    private static String getPropertySuffix(String propertyKey) {
+        if (propertyKey.isEmpty() || propertyKey.charAt(0) != '%') {
+            return propertyKey;
+        }
+        int index = propertyKey.indexOf('.');
+        if (index == -1) {
+            return propertyKey;
+        }
+        return propertyKey.substring(index + 1);
+    }
+
+    private static String fixRegexReferences(String regex) {
+        String temp = regex;
+        Pattern pattern = Pattern.compile(".*?[^\\\\]\\$(\\d+).*");
+        Matcher matcher = pattern.matcher(temp);
+        int start = 0, end = regex.length() - 1;
+
+        while (matcher.region(start, end).matches()) {
+            int value = Integer.parseInt(matcher.group(1));
+            if (value < 1) {
+                throw new IllegalArgumentException("Invalid regex: " + regex);
+            }
+            temp = new StringBuilder(temp).replace(
+                    matcher.start(1), matcher.end(1), String.valueOf(++value)
+            ).toString();
+            start = matcher.end(1);
+            matcher.reset();
+        }
+        return temp;
+    }
+
+    private static String transformString(String oldRegex, String newRegex, String input) {
+        Matcher matcher = Pattern.compile(oldRegex).matcher(input);
+        if (matcher.find()) {
+            StringBuffer result = new StringBuffer();
+            do {
+                matcher.appendReplacement(result, newRegex);
+            } while (matcher.find());
+            matcher.appendTail(result);
+            return result.toString();
+        }
+        return input;
+    }
+}

--- a/src/main/java/org/openrewrite/quarkus/ChangeQuarkusPropertyValue.java
+++ b/src/main/java/org/openrewrite/quarkus/ChangeQuarkusPropertyValue.java
@@ -51,7 +51,7 @@ public class ChangeQuarkusPropertyValue extends Recipe {
     String profile;
 
     @Option(displayName = "Change for all Profiles",
-            description = "If set, thr property will be changed on all available profiles.",
+            description = "If set to true, the property value will be changed on all available profiles. Defaults to `true`.",
             required = false,
             example = "false")
     @Nullable

--- a/src/main/java/org/openrewrite/quarkus/ChangeQuarkusPropertyValue.java
+++ b/src/main/java/org/openrewrite/quarkus/ChangeQuarkusPropertyValue.java
@@ -26,23 +26,22 @@ import java.util.List;
 
 @Value
 @EqualsAndHashCode(callSuper = true)
-public class ChangeQuarkusPropertyKey extends Recipe {
+public class ChangeQuarkusPropertyValue extends Recipe {
 
-    @Option(displayName = "Old property key",
-            description = "The property key to rename. Supports regex.",
-            example = "quarkus.hibernate-search-orm.automatic-indexing.synchronization.strategy")
-    String oldPropertyKey;
-
-    @Option(displayName = "New property key",
-            description = "The new name for the property key. Supports regex.",
+    @Option(displayName = "Property key",
+            description = "The name of the property key whose value is to be changed. Supports regex.",
             example = "quarkus.hibernate-search-orm.indexing.plan.synchronization.strategy")
-    String newPropertyKey;
+    String propertyKey;
 
-    @Option(displayName = "Except",
-            description = "Regex. If any of these property keys exist as direct children of `oldPropertyKey`, then they will not be moved to `newPropertyKey`.",
-            required = false)
+    @Option(displayName = "New value",
+            description = "The new value to be used for key specified by `propertyKey`.")
+    String newValue;
+
+    @Option(displayName = "Old value",
+            required = false,
+            description = "Only change the property value if it matches the configured `oldValue`.")
     @Nullable
-    List<String> except;
+    String oldValue;
 
     @Option(displayName = "Profile",
             description = "The profile where the property is defined. If not specified, the property will be changed on the default profile.",
@@ -71,8 +70,7 @@ public class ChangeQuarkusPropertyKey extends Recipe {
     @Override
     public Validated<Object> validate() {
         Validated<Object> validated = super.validate()
-                .and(Validated.notBlank("newPropertyKey", oldPropertyKey))
-                .and(Validated.notBlank("newPropertyKey", newPropertyKey));
+                .and(Validated.notBlank("propertyKey", propertyKey));
 
         if (StringUtils.isNotEmpty(profile)) {
             validated = validated.and(Validated
@@ -85,20 +83,19 @@ public class ChangeQuarkusPropertyKey extends Recipe {
 
     @Override
     public String getDisplayName() {
-        return "Change Quarkus property key";
+        return "Change Quarkus Property value";
     }
 
     @Override
     public String getDescription() {
-        return "Change a Quarkus property key.";
+        return "Change the value of a property in a Quarkus configuration file.";
     }
 
     @Override
     public TreeVisitor<?, ExecutionContext> getVisitor() {
         return Preconditions.check(
-                new FindQuarkusProperties(oldPropertyKey, profile, changeAllProfiles).getVisitor(),
-                new ChangeQuarkusPropertyKeyVisitor(oldPropertyKey, newPropertyKey, except, profile, changeAllProfiles, pathExpressions)
+                new FindQuarkusProperties(propertyKey, profile, changeAllProfiles).getVisitor(),
+                new ChangeQuarkusPropertyValueVisitor(propertyKey, newValue, oldValue, profile, changeAllProfiles, pathExpressions)
         );
     }
 }
-

--- a/src/main/java/org/openrewrite/quarkus/ChangeQuarkusPropertyValueVisitor.java
+++ b/src/main/java/org/openrewrite/quarkus/ChangeQuarkusPropertyValueVisitor.java
@@ -1,0 +1,168 @@
+/*
+ * Copyright 2023 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.quarkus;
+
+import lombok.RequiredArgsConstructor;
+import org.openrewrite.*;
+import org.openrewrite.internal.lang.Nullable;
+import org.openrewrite.properties.tree.Properties;
+import org.openrewrite.quarkus.search.FindQuarkusProperties;
+import org.openrewrite.yaml.tree.Yaml;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Set;
+
+@RequiredArgsConstructor
+class ChangeQuarkusPropertyValueVisitor extends TreeVisitor<Tree, ExecutionContext> {
+
+    final String propertyKey;
+
+    final String newValue;
+
+    @Nullable
+    final String oldValue;
+
+    @Nullable
+    final String profile;
+
+    @Nullable
+    final Boolean changeAllProfiles;
+
+    @Nullable
+    final List<String> pathExpressions;
+
+    @Override
+    public boolean isAcceptable(SourceFile sourceFile, ExecutionContext ctx) {
+        QuarkusExecutionContextView quarkusCtx = QuarkusExecutionContextView.view(ctx);
+        return quarkusCtx.isQuarkusConfigFile(sourceFile, pathExpressions);
+    }
+
+    @Override
+    public @Nullable Tree visit(@Nullable Tree tree, ExecutionContext ctx) {
+        if (tree instanceof Properties.File) {
+            return visitPropertiesFile(tree, ctx);
+        } else if (tree instanceof Yaml.Documents) {
+            return visitYamlDocuments(tree, ctx);
+        }
+        return tree;
+    }
+
+    private @Nullable Tree visitPropertiesFile(Tree tree, ExecutionContext ctx) {
+        Set<Properties.Entry> existingProperties = FindQuarkusProperties.find((Properties) tree, propertyKey, profile, changeAllProfiles);
+        for (Properties.Entry entry : existingProperties) {
+            if (oldValue == null || oldValue.equals(entry.getValue().getText())) {
+                String[] profiles = QuarkusProfileUtils.getProfilesFromPropertyKey(entry.getKey());
+
+                if (profiles.length == 0 || Boolean.TRUE.equals(changeAllProfiles)) {
+                    tree = new org.openrewrite.properties.ChangePropertyValue(entry.getKey(), newValue, oldValue, false, false)
+                            .getVisitor()
+                            .visit(tree, ctx);
+                } else {
+                    // Remove the old property containing the original key with multiple profiles
+                    tree = new org.openrewrite.properties.DeleteProperty(entry.getKey(), false)
+                            .getVisitor()
+                            .visit(tree, ctx);
+
+                    List<String> remainingProfiles = new ArrayList<>(existingProperties.size());
+                    for (String profile : profiles) {
+                        if (!profile.equals(this.profile)) {
+                            remainingProfiles.add(profile);
+                        }
+                    }
+
+                    String keyWithoutProfile = QuarkusProfileUtils.getKeyWithoutProfile(entry.getKey());
+
+                    // Add a new property for the matched profile
+                    String key = "%" + profile + "." + keyWithoutProfile;
+                    tree = new org.openrewrite.properties.AddProperty(
+                            key,
+                            newValue,
+                            null,
+                            null
+                    ).getVisitor().visit(tree, ctx);
+
+                    if (!remainingProfiles.isEmpty()) {
+                        // Add a property containing the value for the remaining unmatched profiles with the original key
+                        key = "%" + String.join(",", remainingProfiles) + "." + keyWithoutProfile;
+                        String value = entry.getValue().getText();
+                        tree = new org.openrewrite.properties.AddProperty(
+                                key,
+                                value,
+                                null,
+                                null
+                        ).getVisitor().visit(tree, ctx);
+                    }
+                }
+            }
+        }
+
+        return tree;
+    }
+
+    private @Nullable Tree visitYamlDocuments(Tree tree, ExecutionContext ctx) {
+        Set<Yaml.Mapping.Entry> existingProperties = FindQuarkusProperties.find((Yaml.Documents) tree, propertyKey, profile, changeAllProfiles);
+        for (Yaml.Mapping.Entry entry : existingProperties) {
+            String originalEntryValue = ((Yaml.Scalar) entry.getValue()).getValue();
+            if (oldValue == null || oldValue.equals(originalEntryValue)) {
+                String key = entry.getKey().getValue();
+
+                String[] profiles = QuarkusProfileUtils.getProfilesFromPropertyKey(key);
+
+                if (profiles.length == 0 || Boolean.TRUE.equals(changeAllProfiles)) {
+                    tree = new org.openrewrite.yaml.ChangePropertyValue(key, newValue, oldValue, false, null)
+                            .getVisitor()
+                            .visit(tree, ctx);
+                } else {
+                    List<String> remainingProfiles = new ArrayList<>();
+                    for (String profile : profiles) {
+                        if (!profile.equals(this.profile)) {
+                            remainingProfiles.add(profile);
+                        }
+                    }
+
+                    // Remove the old property containing the original key with multiple profiles
+                    tree = new org.openrewrite.yaml.DeleteProperty(key, false, false)
+                            .getVisitor()
+                            .visit(tree, ctx);
+
+                    StringBuilder newProperties = new StringBuilder();
+
+                    String keyWithoutProfile = QuarkusProfileUtils.getKeyWithoutProfile(key);
+
+                    // Add a new property for the named profile with the changed key
+                    QuarkusProfileUtils.formatKey(newProperties, keyWithoutProfile, newValue, profile != null ? Collections.singletonList(profile) : Collections.emptyList());
+
+                    // Add a property containing the value for the unmatched profiles with the original key
+                    if (!remainingProfiles.isEmpty()) {
+                        QuarkusProfileUtils.formatKey(newProperties, keyWithoutProfile, originalEntryValue, remainingProfiles);
+                    }
+
+                    // Merge the new property with the existing properties
+                    tree = new org.openrewrite.yaml.MergeYaml(
+                            "$",
+                            newProperties.toString(),
+                            false,
+                            null
+                    ).getVisitor().visit(tree, ctx);
+                }
+            }
+        }
+
+        return tree;
+    }
+}

--- a/src/main/java/org/openrewrite/quarkus/ChangeQuarkusPropertyValueVisitor.java
+++ b/src/main/java/org/openrewrite/quarkus/ChangeQuarkusPropertyValueVisitor.java
@@ -68,7 +68,7 @@ class ChangeQuarkusPropertyValueVisitor extends TreeVisitor<Tree, ExecutionConte
             if (oldValue == null || oldValue.equals(entry.getValue().getText())) {
                 String[] profiles = QuarkusProfileUtils.getProfilesFromPropertyKey(entry.getKey());
 
-                if (profiles.length == 0 || Boolean.TRUE.equals(changeAllProfiles)) {
+                if (profiles.length == 0 || !Boolean.FALSE.equals(changeAllProfiles)) {
                     tree = new org.openrewrite.properties.ChangePropertyValue(entry.getKey(), newValue, oldValue, false, false)
                             .getVisitor()
                             .visit(tree, ctx);
@@ -123,7 +123,7 @@ class ChangeQuarkusPropertyValueVisitor extends TreeVisitor<Tree, ExecutionConte
 
                 String[] profiles = QuarkusProfileUtils.getProfilesFromPropertyKey(key);
 
-                if (profiles.length == 0 || Boolean.TRUE.equals(changeAllProfiles)) {
+                if (profiles.length == 0 || !Boolean.FALSE.equals(changeAllProfiles)) {
                     tree = new org.openrewrite.yaml.ChangePropertyValue(key, newValue, oldValue, false, null)
                             .getVisitor()
                             .visit(tree, ctx);

--- a/src/main/java/org/openrewrite/quarkus/DeleteQuarkusProperty.java
+++ b/src/main/java/org/openrewrite/quarkus/DeleteQuarkusProperty.java
@@ -51,12 +51,12 @@ public class DeleteQuarkusProperty extends Recipe {
     @Nullable
     String profile;
 
-    @Option(displayName = "Change for all Profiles",
-            description = "If set, thr property will be changed on all available profiles.",
+    @Option(displayName = "Delete from all Profiles",
+            description = "If set to true, the property will be removed from all available profiles. Defaults to `true`.",
             required = false,
             example = "false")
     @Nullable
-    Boolean deleteOnAllProfiles;
+    Boolean deleteFromAllProfiles;
 
     @Option(displayName = "Optional list of file path matcher",
             description = "Each value in this list represents a glob expression that is used to match which files will " +
@@ -75,7 +75,7 @@ public class DeleteQuarkusProperty extends Recipe {
 
         if (StringUtils.isNotEmpty(profile)) {
             validated = validated.and(Validated
-                    .test("deleteOnAllProfiles", "cannot be used together with profile", deleteOnAllProfiles, x -> x == null || !x)
+                    .test("deleteOnAllProfiles", "cannot be used together with profile", deleteFromAllProfiles, x -> x == null || !x)
             );
         }
 
@@ -95,8 +95,8 @@ public class DeleteQuarkusProperty extends Recipe {
     @Override
     public TreeVisitor<?, ExecutionContext> getVisitor() {
         return Preconditions.check(
-                new FindQuarkusProperties(propertyKey, profile, deleteOnAllProfiles).getVisitor(),
-                new DeleteQuarkusPropertyVisitor(propertyKey, oldValue, profile, deleteOnAllProfiles, pathExpressions)
+                new FindQuarkusProperties(propertyKey, profile, deleteFromAllProfiles).getVisitor(),
+                new DeleteQuarkusPropertyVisitor(propertyKey, oldValue, profile, deleteFromAllProfiles, pathExpressions)
         );
     }
 }

--- a/src/main/java/org/openrewrite/quarkus/DeleteQuarkusPropertyVisitor.java
+++ b/src/main/java/org/openrewrite/quarkus/DeleteQuarkusPropertyVisitor.java
@@ -68,7 +68,7 @@ public class DeleteQuarkusPropertyVisitor extends TreeVisitor<Tree, ExecutionCon
             if (oldValue == null || oldValue.equals(entry.getValue().getText())) {
                 String[] profiles = QuarkusProfileUtils.getProfilesFromPropertyKey(entry.getKey());
 
-                if (profiles.length == 0 || Boolean.TRUE.equals(searchAllProfiles)) {
+                if (profiles.length == 0 || !Boolean.FALSE.equals(searchAllProfiles)) {
                     tree = new org.openrewrite.properties.DeleteProperty(entry.getKey(), false)
                             .getVisitor()
                             .visit(tree, ctx);
@@ -114,7 +114,7 @@ public class DeleteQuarkusPropertyVisitor extends TreeVisitor<Tree, ExecutionCon
 
                 String[] profiles = QuarkusProfileUtils.getProfilesFromPropertyKey(key);
 
-                if (profiles.length == 0 || Boolean.TRUE.equals(searchAllProfiles)) {
+                if (profiles.length == 0 || !Boolean.FALSE.equals(searchAllProfiles)) {
                     tree = new org.openrewrite.yaml.DeleteProperty(key, false, null)
                             .getVisitor()
                             .visit(tree, ctx);

--- a/src/main/java/org/openrewrite/quarkus/DeleteQuarkusPropertyVisitor.java
+++ b/src/main/java/org/openrewrite/quarkus/DeleteQuarkusPropertyVisitor.java
@@ -1,0 +1,154 @@
+/*
+ * Copyright 2023 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.quarkus;
+
+import lombok.RequiredArgsConstructor;
+import org.openrewrite.ExecutionContext;
+import org.openrewrite.SourceFile;
+import org.openrewrite.Tree;
+import org.openrewrite.TreeVisitor;
+import org.openrewrite.internal.lang.Nullable;
+import org.openrewrite.properties.tree.Properties;
+import org.openrewrite.quarkus.search.FindQuarkusProperties;
+import org.openrewrite.yaml.tree.Yaml;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+
+@RequiredArgsConstructor
+public class DeleteQuarkusPropertyVisitor extends TreeVisitor<Tree, ExecutionContext> {
+
+    final String propertyKey;
+
+    @Nullable
+    final String oldValue;
+
+    @Nullable
+    final String profile;
+
+    @Nullable
+    final Boolean searchAllProfiles;
+
+    @Nullable
+    final List<String> pathExpressions;
+
+    @Override
+    public boolean isAcceptable(SourceFile sourceFile, ExecutionContext ctx) {
+        QuarkusExecutionContextView quarkusCtx = QuarkusExecutionContextView.view(ctx);
+        return quarkusCtx.isQuarkusConfigFile(sourceFile, pathExpressions);
+    }
+
+    @Override
+    public @Nullable Tree visit(@Nullable Tree tree, ExecutionContext ctx) {
+        if (tree instanceof Properties.File) {
+            return visitPropertiesFile(tree, ctx);
+        } else if (tree instanceof Yaml.Documents) {
+            return visitYamlDocuments(tree, ctx);
+        }
+        return tree;
+    }
+
+    private @Nullable Tree visitPropertiesFile(Tree tree, ExecutionContext ctx) {
+        Set<Properties.Entry> existingProperties = FindQuarkusProperties.find((Properties) tree, propertyKey, profile, searchAllProfiles);
+        for (Properties.Entry entry : existingProperties) {
+            if (oldValue == null || oldValue.equals(entry.getValue().getText())) {
+                String[] profiles = QuarkusProfileUtils.getProfilesFromPropertyKey(entry.getKey());
+
+                if (profiles.length == 0 || Boolean.TRUE.equals(searchAllProfiles)) {
+                    tree = new org.openrewrite.properties.DeleteProperty(entry.getKey(), false)
+                            .getVisitor()
+                            .visit(tree, ctx);
+                } else {
+                    // Remove the old property containing the original key with multiple profiles
+                    tree = new org.openrewrite.properties.DeleteProperty(entry.getKey(), false)
+                            .getVisitor()
+                            .visit(tree, ctx);
+
+                    List<String> remainingProfiles = new ArrayList<>(existingProperties.size());
+                    for (String profile : profiles) {
+                        if (!profile.equals(this.profile)) {
+                            remainingProfiles.add(profile);
+                        }
+                    }
+
+                    if (!remainingProfiles.isEmpty()) {
+                        String keyWithoutProfile = QuarkusProfileUtils.getKeyWithoutProfile(entry.getKey());
+
+                        // Add a property containing the value for the remaining unmatched profiles with the original key
+                        String key = "%" + String.join(",", remainingProfiles) + "." + keyWithoutProfile;
+                        String value = entry.getValue().getText();
+                        tree = new org.openrewrite.properties.AddProperty(
+                                key,
+                                value,
+                                null,
+                                null
+                        ).getVisitor().visit(tree, ctx);
+                    }
+                }
+            }
+        }
+
+        return tree;
+    }
+
+    private @Nullable Tree visitYamlDocuments(Tree tree, ExecutionContext ctx) {
+        Set<Yaml.Mapping.Entry> existingProperties = FindQuarkusProperties.find((Yaml.Documents) tree, propertyKey, profile, searchAllProfiles);
+        for (Yaml.Mapping.Entry entry : existingProperties) {
+            String originalEntryValue = ((Yaml.Scalar) entry.getValue()).getValue();
+            if (oldValue == null || oldValue.equals(originalEntryValue)) {
+                String key = entry.getKey().getValue();
+
+                String[] profiles = QuarkusProfileUtils.getProfilesFromPropertyKey(key);
+
+                if (profiles.length == 0 || Boolean.TRUE.equals(searchAllProfiles)) {
+                    tree = new org.openrewrite.yaml.DeleteProperty(key, false, null)
+                            .getVisitor()
+                            .visit(tree, ctx);
+                } else {
+                    // Remove the old property containing the original key with multiple profiles
+                    tree = new org.openrewrite.yaml.DeleteProperty(key, false, false)
+                            .getVisitor()
+                            .visit(tree, ctx);
+
+                    List<String> remainingProfiles = new ArrayList<>();
+                    for (String profile : profiles) {
+                        if (!profile.equals(this.profile)) {
+                            remainingProfiles.add(profile);
+                        }
+                    }
+
+                    // Add a property containing the value for the unmatched profiles with the original key
+                    if (!remainingProfiles.isEmpty()) {
+                        StringBuilder newProperties = new StringBuilder();
+                        String keyWithoutProfile = QuarkusProfileUtils.getKeyWithoutProfile(key);
+                        QuarkusProfileUtils.formatKey(newProperties, keyWithoutProfile, originalEntryValue, remainingProfiles);
+
+                        // Merge the new property with the existing properties
+                        tree = new org.openrewrite.yaml.MergeYaml(
+                                "$",
+                                newProperties.toString(),
+                                false,
+                                null
+                        ).getVisitor().visit(tree, ctx);
+                    }
+                }
+            }
+        }
+
+        return tree;
+    }
+}

--- a/src/main/java/org/openrewrite/quarkus/QuarkusExecutionContextView.java
+++ b/src/main/java/org/openrewrite/quarkus/QuarkusExecutionContextView.java
@@ -17,10 +17,13 @@ package org.openrewrite.quarkus;
 
 import org.openrewrite.DelegatingExecutionContext;
 import org.openrewrite.ExecutionContext;
-import org.openrewrite.PathUtils;
+import org.openrewrite.SourceFile;
+import org.openrewrite.Tree;
 import org.openrewrite.internal.lang.Nullable;
+import org.openrewrite.properties.tree.Properties;
+import org.openrewrite.yaml.tree.Yaml;
 
-import java.nio.file.Path;
+import java.nio.file.FileSystems;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
@@ -66,7 +69,10 @@ public class QuarkusExecutionContextView extends DelegatingExecutionContext {
         );
     }
 
-    public boolean isQuarkusConfigFile(Path sourcePath, @Nullable List<String> pathExpressions) {
+    public boolean isQuarkusConfigFile(Tree tree, @Nullable List<String> pathExpressions) {
+        if (!(tree instanceof Properties.File || tree instanceof Yaml.Documents)) {
+            return false;
+        }
         List<String> expressions = pathExpressions != null ? pathExpressions : Collections.emptyList();
         if (expressions.isEmpty()) {
             // If not defined, get reasonable defaults from the execution context.
@@ -76,7 +82,7 @@ public class QuarkusExecutionContextView extends DelegatingExecutionContext {
             return true;
         }
         for (String filePattern : expressions) {
-            if (PathUtils.matchesGlob(sourcePath, filePattern)) {
+            if (FileSystems.getDefault().getPathMatcher("glob:" + filePattern).matches(((SourceFile)tree).getSourcePath())) {
                 return true;
             }
         }

--- a/src/main/java/org/openrewrite/quarkus/QuarkusExecutionContextView.java
+++ b/src/main/java/org/openrewrite/quarkus/QuarkusExecutionContextView.java
@@ -17,8 +17,12 @@ package org.openrewrite.quarkus;
 
 import org.openrewrite.DelegatingExecutionContext;
 import org.openrewrite.ExecutionContext;
+import org.openrewrite.PathUtils;
+import org.openrewrite.internal.lang.Nullable;
 
+import java.nio.file.Path;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 
 public class QuarkusExecutionContextView extends DelegatingExecutionContext {
@@ -60,5 +64,23 @@ public class QuarkusExecutionContextView extends DelegatingExecutionContext {
         return getMessage(DEFAULT_APPLICATION_CONFIGURATION_PATHS,
                 Arrays.asList("**/application.{properties,yaml,yml}", "**/META-INF/microprofile-config.properties")
         );
+    }
+
+    public boolean isQuarkusConfigFile(Path sourcePath, @Nullable List<String> pathExpressions) {
+        List<String> expressions = pathExpressions != null ? pathExpressions : Collections.emptyList();
+        if (expressions.isEmpty()) {
+            // If not defined, get reasonable defaults from the execution context.
+            expressions = getDefaultApplicationConfigurationPaths();
+        }
+        if (expressions.isEmpty()) {
+            return true;
+        }
+        for (String filePattern : expressions) {
+            if (PathUtils.matchesGlob(sourcePath, filePattern)) {
+                return true;
+            }
+        }
+
+        return false;
     }
 }

--- a/src/main/java/org/openrewrite/quarkus/QuarkusExecutionContextView.java
+++ b/src/main/java/org/openrewrite/quarkus/QuarkusExecutionContextView.java
@@ -78,9 +78,6 @@ public class QuarkusExecutionContextView extends DelegatingExecutionContext {
             // If not defined, get reasonable defaults from the execution context.
             expressions = getDefaultApplicationConfigurationPaths();
         }
-        if (expressions.isEmpty()) {
-            return true;
-        }
         for (String filePattern : expressions) {
             if (FileSystems.getDefault().getPathMatcher("glob:" + filePattern).matches(((SourceFile)tree).getSourcePath())) {
                 return true;

--- a/src/main/java/org/openrewrite/quarkus/QuarkusProfileUtils.java
+++ b/src/main/java/org/openrewrite/quarkus/QuarkusProfileUtils.java
@@ -1,0 +1,56 @@
+package org.openrewrite.quarkus;
+
+import java.util.List;
+
+class QuarkusProfileUtils {
+
+    private QuarkusProfileUtils() {
+    }
+
+    static String getKeyWithoutProfile(String propertyKey) {
+        if (propertyKey.isEmpty() || propertyKey.charAt(0) != '%') {
+            return propertyKey;
+        }
+        int index = propertyKey.indexOf('.');
+        if (index == -1) {
+            return propertyKey;
+        }
+        return propertyKey.substring(index + 1);
+    }
+
+    static String[] getProfilesFromPropertyKey(String propertyKey) {
+        if (propertyKey.isEmpty() || propertyKey.charAt(0) != '%') {
+            return new String[0];
+        }
+        int index = propertyKey.indexOf('.');
+        if (index == -1) {
+            return new String[0];
+        }
+        return propertyKey.substring(1, index).split(",");
+    }
+
+    static void formatKey(StringBuilder yaml, String property, String value, List<String> profiles) {
+        String[] propertyParts = property.split("\\.");
+
+        String indent = "";
+        if (!profiles.isEmpty()) {
+            yaml.append("'%")
+                    .append(java.lang.String.join(",", profiles))
+                    .append("':")
+                    .append(System.lineSeparator());
+            indent = indent + "  ";
+        }
+        for (int i = 0; i < propertyParts.length; i++) {
+            String part = propertyParts[i];
+            if (i > 0 && yaml.length() > 0) {
+                yaml.append(System.lineSeparator());
+            }
+            yaml.append(indent).append(part).append(":");
+            indent = indent + "  ";
+        }
+        yaml.append(" ").append(value);
+        if (yaml.length() > 0) {
+            yaml.append(System.lineSeparator());
+        }
+    }
+}

--- a/src/main/java/org/openrewrite/quarkus/QuarkusProfileUtils.java
+++ b/src/main/java/org/openrewrite/quarkus/QuarkusProfileUtils.java
@@ -1,5 +1,23 @@
+/*
+ * Copyright 2024 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.openrewrite.quarkus;
 
+import org.openrewrite.internal.StringUtils;
+
+import java.util.Collections;
 import java.util.List;
 
 class QuarkusProfileUtils {
@@ -27,6 +45,12 @@ class QuarkusProfileUtils {
             return new String[0];
         }
         return propertyKey.substring(1, index).split(",");
+    }
+
+    static String formatKey(String property, String value, String profile) {
+        StringBuilder yaml = new StringBuilder();
+        formatKey(yaml, property, value, StringUtils.isNotEmpty(profile) ? Collections.singletonList(profile) : Collections.emptyList());
+        return yaml.toString();
     }
 
     static void formatKey(StringBuilder yaml, String property, String value, List<String> profiles) {

--- a/src/main/java/org/openrewrite/quarkus/search/FindQuarkusProfiles.java
+++ b/src/main/java/org/openrewrite/quarkus/search/FindQuarkusProfiles.java
@@ -17,12 +17,7 @@ package org.openrewrite.quarkus.search;
 
 import lombok.EqualsAndHashCode;
 import lombok.Value;
-import org.openrewrite.Cursor;
-import org.openrewrite.ExecutionContext;
-import org.openrewrite.Recipe;
-import org.openrewrite.SourceFile;
-import org.openrewrite.Tree;
-import org.openrewrite.TreeVisitor;
+import org.openrewrite.*;
 import org.openrewrite.internal.lang.Nullable;
 import org.openrewrite.marker.SearchResult;
 import org.openrewrite.properties.PropertiesIsoVisitor;
@@ -33,7 +28,6 @@ import org.openrewrite.yaml.tree.Yaml;
 
 import java.util.Arrays;
 import java.util.HashSet;
-import java.util.Iterator;
 import java.util.Set;
 
 /**
@@ -92,8 +86,8 @@ public class FindQuarkusProfiles extends Recipe {
     /**
      * Find Quarkus profiles in the given tree.
      *
-     * @param tree The tree to search for Quarkus profiles.
-     * @return A set of Quarkus profiles.
+     * @param tree The {@link Properties} or {@link Yaml.Documents} tree to search for Quarkus profiles.
+     * @return The Quarkus profiles in use on the tree.
      */
     public static Set<String> find(Tree tree) {
         Set<String> profiles = new HashSet<>();
@@ -116,7 +110,7 @@ public class FindQuarkusProfiles extends Recipe {
                         @Override
                         public Yaml.Mapping.Entry visitMappingEntry(Yaml.Mapping.Entry entry, Set<String> ctx) {
                             entry = super.visitMappingEntry(entry, ctx);
-                            String prop = getProperty(getCursor());
+                            String prop = FindQuarkusProperties.getProperty(getCursor());
                             addProfile(prop, ctx);
                             return entry;
                         }
@@ -138,22 +132,5 @@ public class FindQuarkusProfiles extends Recipe {
         }
         String temp = propertyKey.substring(1, index);
         profiles.addAll(Arrays.asList(temp.split(",")));
-    }
-
-    private static String getProperty(Cursor cursor) {
-        StringBuilder asProperty = new StringBuilder();
-        Iterator<Object> path = cursor.getPath();
-        int i = 0;
-        while (path.hasNext()) {
-            Object next = path.next();
-            if (next instanceof Yaml.Mapping.Entry) {
-                Yaml.Mapping.Entry entry = (Yaml.Mapping.Entry) next;
-                if (i++ > 0) {
-                    asProperty.insert(0, '.');
-                }
-                asProperty.insert(0, entry.getKey().getValue());
-            }
-        }
-        return asProperty.toString();
     }
 }

--- a/src/main/java/org/openrewrite/quarkus/search/FindQuarkusProfiles.java
+++ b/src/main/java/org/openrewrite/quarkus/search/FindQuarkusProfiles.java
@@ -37,7 +37,7 @@ import java.util.Iterator;
 import java.util.Set;
 
 /**
- * This recipe is used to find Quarkus properties.
+ * This recipe is used to find Quarkus profiles.
  */
 @Value
 @EqualsAndHashCode(callSuper = true)

--- a/src/main/java/org/openrewrite/quarkus/search/FindQuarkusProfiles.java
+++ b/src/main/java/org/openrewrite/quarkus/search/FindQuarkusProfiles.java
@@ -1,0 +1,141 @@
+/*
+ * Copyright 2023 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.quarkus.search;
+
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.Value;
+import org.openrewrite.Cursor;
+import org.openrewrite.ExecutionContext;
+import org.openrewrite.InMemoryExecutionContext;
+import org.openrewrite.Preconditions;
+import org.openrewrite.Recipe;
+import org.openrewrite.SourceFile;
+import org.openrewrite.Tree;
+import org.openrewrite.TreeVisitor;
+import org.openrewrite.internal.lang.Nullable;
+import org.openrewrite.properties.PropertiesIsoVisitor;
+import org.openrewrite.properties.tree.Properties;
+import org.openrewrite.quarkus.QuarkusExecutionContextView;
+import org.openrewrite.yaml.YamlIsoVisitor;
+import org.openrewrite.yaml.tree.Yaml;
+
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.Set;
+
+/**
+ * This recipe is used to find Quarkus properties.
+ */
+@Value
+@EqualsAndHashCode(callSuper = true)
+public class FindQuarkusProfiles extends Recipe {
+
+    @Override
+    public String getDisplayName() {
+        return "Search Quarkus profiles";
+    }
+
+    @Override
+    public String getDescription() {
+        return "Search the properties for existing Quarkus profiles.";
+    }
+
+    @Override
+    public TreeVisitor<?, ExecutionContext> getVisitor() {
+        return Preconditions.check(
+                new TreeVisitor<Tree, ExecutionContext>() {
+                    @Override
+                    public boolean isAcceptable(SourceFile sourceFile, ExecutionContext executionContext) {
+                        QuarkusExecutionContextView quarkusCtx = QuarkusExecutionContextView.view(executionContext);
+                        return sourceFile instanceof Properties.File || sourceFile instanceof Yaml.Documents &&
+                                                                        quarkusCtx.isQuarkusConfigFile(sourceFile.getSourcePath(), null);
+                    }
+                },
+                new FindQuarkusProfilesVisitor()
+        );
+    }
+
+    private static class FindQuarkusProfilesVisitor extends TreeVisitor<Tree, ExecutionContext> {
+
+        @Getter
+        private final Set<String> profiles = new HashSet<>();
+
+        @Override
+        public @Nullable Tree visit(@Nullable Tree tree, ExecutionContext ctx) {
+            tree = super.visit(tree, ctx);
+            if (tree instanceof Properties.File) {
+                Properties.File propertiesFile = (Properties.File) tree;
+                new PropertiesIsoVisitor<Set<String>>() {
+                    @Override
+                    public Properties.Entry visitEntry(Properties.Entry entry, Set<String> ctx) {
+                        entry = super.visitEntry(entry, ctx);
+                        addProfile(entry.getKey(), ctx);
+                        return entry;
+                    }
+                }.reduce(propertiesFile, profiles);
+            } else if (tree instanceof Yaml.Documents) {
+                Yaml.Documents yamlDocuments = (Yaml.Documents) tree;
+                new YamlIsoVisitor<Set<String>>() {
+                    @Override
+                    public Yaml.Mapping.Entry visitMappingEntry(Yaml.Mapping.Entry entry, Set<String> ctx) {
+                        entry = super.visitMappingEntry(entry, ctx);
+                        String prop = getProperty(getCursor());
+                        addProfile(prop, ctx);
+                        return entry;
+                    }
+                }.reduce(yamlDocuments, profiles);
+            }
+            return tree;
+        }
+    }
+
+    public static Set<String> find(Tree tree) {
+        FindQuarkusProfilesVisitor visitor = new FindQuarkusProfilesVisitor();
+        visitor.visit(tree, new InMemoryExecutionContext());
+        return visitor.getProfiles();
+    }
+
+    private static void addProfile(String propertyKey, Set<String> profiles) {
+        if (propertyKey.isEmpty() || propertyKey.charAt(0) != '%') {
+            return;
+        }
+        int index = propertyKey.indexOf('.');
+        if (index == -1) {
+            return;
+        }
+        String temp = propertyKey.substring(1, index);
+        profiles.addAll(Arrays.asList(temp.split(",")));
+    }
+
+    private static String getProperty(Cursor cursor) {
+        StringBuilder asProperty = new StringBuilder();
+        Iterator<Object> path = cursor.getPath();
+        int i = 0;
+        while (path.hasNext()) {
+            Object next = path.next();
+            if (next instanceof Yaml.Mapping.Entry) {
+                Yaml.Mapping.Entry entry = (Yaml.Mapping.Entry) next;
+                if (i++ > 0) {
+                    asProperty.insert(0, '.');
+                }
+                asProperty.insert(0, entry.getKey().getValue());
+            }
+        }
+        return asProperty.toString();
+    }
+}

--- a/src/main/java/org/openrewrite/quarkus/search/FindQuarkusProperties.java
+++ b/src/main/java/org/openrewrite/quarkus/search/FindQuarkusProperties.java
@@ -1,0 +1,212 @@
+/*
+ * Copyright 2023 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.quarkus.search;
+
+import lombok.EqualsAndHashCode;
+import lombok.Value;
+import org.openrewrite.Cursor;
+import org.openrewrite.ExecutionContext;
+import org.openrewrite.Option;
+import org.openrewrite.Recipe;
+import org.openrewrite.SourceFile;
+import org.openrewrite.Tree;
+import org.openrewrite.TreeVisitor;
+import org.openrewrite.Validated;
+import org.openrewrite.internal.StringUtils;
+import org.openrewrite.internal.lang.Nullable;
+import org.openrewrite.marker.SearchResult;
+import org.openrewrite.properties.PropertiesIsoVisitor;
+import org.openrewrite.properties.PropertiesVisitor;
+import org.openrewrite.properties.tree.Properties;
+import org.openrewrite.yaml.YamlIsoVisitor;
+import org.openrewrite.yaml.tree.Yaml;
+
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.Set;
+import java.util.regex.Pattern;
+
+import static org.openrewrite.Tree.randomId;
+
+@Value
+@EqualsAndHashCode(callSuper = true)
+public class FindQuarkusProperties extends Recipe {
+
+    @Override
+    public String getDisplayName() {
+        return "Find Quarkus property";
+    }
+
+    @Override
+    public String getDescription() {
+        return "Finds occurrences of a Quarkus property key.";
+    }
+
+    @Option(displayName = "Property key",
+            description = "The property key to look for.",
+            example = "quarkus.http.port")
+    String propertyKey;
+
+    @Option(displayName = "Profile",
+            description = "The profile where the property is defined. If not specified, the property will be changed on the default profile.",
+            required = false,
+            example = "dev")
+    @Nullable
+    String profile;
+
+    @Option(displayName = "Search on all Profiles",
+            description = "If set, the property will be searched on all available profiles.",
+            required = false,
+            example = "false")
+    @Nullable
+    Boolean searchAllProfiles;
+
+    @Override
+    public Validated<Object> validate() {
+        Validated<Object> validated = super.validate()
+                .and(Validated.notBlank("propertyKey", propertyKey));
+
+        if (StringUtils.isNotEmpty(profile)) {
+            validated = validated.and(Validated
+                    .test("searchAllProfiles", "cannot be used together with profile", searchAllProfiles, x -> x == null || !x)
+            );
+        }
+
+        return validated;
+    }
+
+    /**
+     * Find a set of matching {@link Properties}.
+     *
+     * @param p                 The set of properties to search over.
+     * @param propertyKey       The name of property key to look for.
+     * @param profile           The profile where the property is defined. If not specified, the property will be changed on the default profile.
+     * @param searchAllProfiles If set, the property will be searched on all available profiles.
+     * @return The set of found properties matching the propertyKey.
+     */
+    public static Set<Properties.Entry> find(Properties p, String propertyKey, @Nullable String profile, @Nullable Boolean searchAllProfiles) {
+        final Pattern pattern = Pattern.compile(getSearchRegex(propertyKey, profile, searchAllProfiles));
+        PropertiesIsoVisitor<Set<Properties.Entry>> findVisitor = new PropertiesIsoVisitor<Set<Properties.Entry>>() {
+            @Override
+            public Properties.Entry visitEntry(Properties.Entry entry, Set<Properties.Entry> ps) {
+                if (pattern.matcher(entry.getKey()).find()) {
+                    ps.add(entry);
+                }
+                return super.visitEntry(entry, ps);
+            }
+        };
+
+        Set<Properties.Entry> ps = new HashSet<>();
+        findVisitor.visit(p, ps);
+        return ps;
+    }
+
+    /**
+     * Find a set of matching {@link Properties}.
+     *
+     * @param y                 The set of properties to search over.
+     * @param propertyKey       The name of property key to look for.
+     * @param profile           The profile where the property is defined. If not specified, the property will be changed on the default profile.
+     * @param searchAllProfiles If set, the property will be searched on all available profiles.
+     * @return The set of found properties matching the propertyKey.
+     */
+    public static Set<Properties.Entry> find(Yaml.Documents y, String propertyKey, @Nullable String profile, @Nullable Boolean searchAllProfiles) {
+        final Pattern pattern = Pattern.compile(getSearchRegex(propertyKey, profile, searchAllProfiles));
+        YamlIsoVisitor<Set<Properties.Entry>> findVisitor = new YamlIsoVisitor<Set<Properties.Entry>>() {
+            @Override
+            public Yaml.Mapping.Entry visitMappingEntry(Yaml.Mapping.Entry entry, Set<Properties.Entry> entries) {
+                entry = super.visitMappingEntry(entry, entries);
+                if (pattern.matcher(entry.getKey().getValue()).find()) {
+                    entry = entry.withValue(entry.getValue().withMarkers(entry.getValue().getMarkers()
+                            .computeByType(new SearchResult(randomId(), null), (s1, s2) -> s1 == null ? s2 : s1)));
+                }
+                return entry;
+            }
+        };
+
+        Set<Properties.Entry> ps = new HashSet<>();
+        findVisitor.visit(y, ps);
+        return ps;
+    }
+
+    @Override
+    public TreeVisitor<?, ExecutionContext> getVisitor() {
+        final Pattern pattern = Pattern.compile(getSearchRegex(propertyKey, profile, searchAllProfiles));
+
+        return new TreeVisitor<Tree, ExecutionContext>() {
+            @Override
+            public boolean isAcceptable(SourceFile sourceFile, ExecutionContext ctx) {
+                return sourceFile instanceof Yaml.Documents || sourceFile instanceof Properties.File;
+            }
+
+            @Override
+            public @Nullable Tree visit(@Nullable Tree t, ExecutionContext ctx) {
+                if (t instanceof Yaml.Documents) {
+                    t = new YamlIsoVisitor<ExecutionContext>() {
+                        @Override
+                        public Yaml.Mapping.Entry visitMappingEntry(Yaml.Mapping.Entry entry, ExecutionContext ctx) {
+                            entry = super.visitMappingEntry(entry, ctx);
+                            String prop = getProperty(getCursor());
+                            if (pattern.matcher(prop).find()) {
+                                entry = entry.withValue(entry.getValue().withMarkers(entry.getValue().getMarkers()
+                                        .computeByType(new SearchResult(randomId(), null), (s1, s2) -> s1 == null ? s2 : s1)));
+                            }
+                            return entry;
+                        }
+                    }.visit(t, ctx);
+                } else if (t instanceof Properties.File) {
+                    t = new PropertiesVisitor<ExecutionContext>() {
+                        @Override
+                        public Properties visitEntry(Properties.Entry entry, ExecutionContext ctx) {
+                            if (pattern.matcher(entry.getKey()).find()) {
+                                entry = entry.withValue(entry.getValue().withMarkers(entry.getValue().getMarkers()
+                                        .computeByType(new SearchResult(randomId(), null), (s1, s2) -> s1 == null ? s2 : s1)));
+                            }
+                            return super.visitEntry(entry, ctx);
+                        }
+                    }.visit(t, ctx);
+                }
+                return t;
+            }
+        };
+    }
+
+    private static String getSearchRegex(String propertyKey, String profile, Boolean searchAllProfiles) {
+        if (searchAllProfiles != null && searchAllProfiles) {
+            return "^(?:%[\\w\\-_,]+\\.)?" + propertyKey + "$";
+        } else if (StringUtils.isNotEmpty(profile)) {
+            return "^%[\\w\\-_,]*(?:" + profile + ")[\\w\\-_,]*\\." + propertyKey + "$";
+        }
+        return "^" + propertyKey + "$";
+    }
+
+    private static String getProperty(Cursor cursor) {
+        StringBuilder asProperty = new StringBuilder();
+        Iterator<Object> path = cursor.getPath();
+        int i = 0;
+        while (path.hasNext()) {
+            Object next = path.next();
+            if (next instanceof Yaml.Mapping.Entry) {
+                Yaml.Mapping.Entry entry = (Yaml.Mapping.Entry) next;
+                if (i++ > 0) {
+                    asProperty.insert(0, '.');
+                }
+                asProperty.insert(0, entry.getKey().getValue());
+            }
+        }
+        return asProperty.toString();
+    }
+}

--- a/src/main/java/org/openrewrite/quarkus/search/FindQuarkusProperties.java
+++ b/src/main/java/org/openrewrite/quarkus/search/FindQuarkusProperties.java
@@ -31,6 +31,7 @@ import org.openrewrite.marker.SearchResult;
 import org.openrewrite.properties.PropertiesIsoVisitor;
 import org.openrewrite.properties.PropertiesVisitor;
 import org.openrewrite.properties.tree.Properties;
+import org.openrewrite.quarkus.QuarkusExecutionContextView;
 import org.openrewrite.yaml.YamlIsoVisitor;
 import org.openrewrite.yaml.tree.Yaml;
 
@@ -149,7 +150,8 @@ public class FindQuarkusProperties extends Recipe {
         return new TreeVisitor<Tree, ExecutionContext>() {
             @Override
             public boolean isAcceptable(SourceFile sourceFile, ExecutionContext ctx) {
-                return sourceFile instanceof Yaml.Documents || sourceFile instanceof Properties.File;
+                QuarkusExecutionContextView quarkusCtx = QuarkusExecutionContextView.view(ctx);
+                return quarkusCtx.isQuarkusConfigFile(sourceFile, null);
             }
 
             @Override

--- a/src/main/java/org/openrewrite/quarkus/search/FindQuarkusProperties.java
+++ b/src/main/java/org/openrewrite/quarkus/search/FindQuarkusProperties.java
@@ -194,7 +194,7 @@ public class FindQuarkusProperties extends Recipe {
         };
     }
 
-    private static String getSearchRegex(String propertyKey, String profile, Boolean searchAllProfiles) {
+    private static String getSearchRegex(String propertyKey, @Nullable String profile, @Nullable Boolean searchAllProfiles) {
         if (Boolean.TRUE.equals(searchAllProfiles)) {
             return "^(?:%[\\w\\-_,]+\\.)?" + propertyKey + "$";
         } else if (StringUtils.isNotEmpty(profile)) {

--- a/src/main/java/org/openrewrite/quarkus/search/FindQuarkusProperties.java
+++ b/src/main/java/org/openrewrite/quarkus/search/FindQuarkusProperties.java
@@ -36,9 +36,11 @@ import org.openrewrite.yaml.YamlIsoVisitor;
 import org.openrewrite.yaml.tree.Yaml;
 import org.openrewrite.yaml.tree.YamlKey;
 
+import java.util.Comparator;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.Set;
+import java.util.TreeSet;
 import java.util.regex.Pattern;
 
 @Value
@@ -109,7 +111,7 @@ public class FindQuarkusProperties extends Recipe {
             }
         };
 
-        Set<Properties.Entry> entries = new HashSet<>();
+        Set<Properties.Entry> entries = new TreeSet<>(Comparator.comparing(Properties.Entry::getKey));
         findVisitor.visit(p, entries);
         return entries;
     }
@@ -141,7 +143,12 @@ public class FindQuarkusProperties extends Recipe {
             }
         };
 
-        Set<Yaml.Mapping.Entry> entries = new HashSet<>();
+        Set<Yaml.Mapping.Entry> entries = new TreeSet<>((o1, o2) -> {
+            if (o1.getKey() instanceof Yaml.Scalar && o2.getKey() instanceof Yaml.Scalar) {
+                return o1.getKey().getValue().compareTo(o2.getKey().getValue());
+            }
+            return 0;
+        });
         findVisitor.visit(y, entries);
         return entries;
     }

--- a/src/main/java/org/openrewrite/quarkus/search/FindQuarkusProperties.java
+++ b/src/main/java/org/openrewrite/quarkus/search/FindQuarkusProperties.java
@@ -55,14 +55,14 @@ public class FindQuarkusProperties extends Recipe {
     String propertyKey;
 
     @Option(displayName = "Profile",
-            description = "The profile where the property is defined. If not specified, the property will be changed on the default profile.",
+            description = "The profile where the property is defined. If not specified, the property will be searched on all profiles.",
             required = false,
             example = "dev")
     @Nullable
     String profile;
 
     @Option(displayName = "Search on all Profiles",
-            description = "If set, the property will be searched on all available profiles.",
+            description = "If set, the property will be searched on all available profiles. Defaults to `true`.",
             required = false,
             example = "false")
     @Nullable
@@ -187,7 +187,7 @@ public class FindQuarkusProperties extends Recipe {
     }
 
     private static String getSearchRegex(String propertyKey, @Nullable String profile, @Nullable Boolean searchAllProfiles) {
-        if (Boolean.TRUE.equals(searchAllProfiles)) {
+        if (!Boolean.FALSE.equals(searchAllProfiles)) {
             return "^(?:%[\\w\\-_,]+\\.)?" + propertyKey + "$";
         } else if (StringUtils.isNotEmpty(profile)) {
             return "^%[\\w\\-_,]*(?:" + profile + ")[\\w\\-_,]*\\." + propertyKey + "$";

--- a/src/main/java/org/openrewrite/quarkus/search/package-info.java
+++ b/src/main/java/org/openrewrite/quarkus/search/package-info.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright 2024 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+@NonNullApi
+@NonNullFields
+package org.openrewrite.quarkus.search;
+
+import org.openrewrite.internal.lang.NonNullApi;
+import org.openrewrite.internal.lang.NonNullFields;

--- a/src/test/java/org/openrewrite/quarkus/AddQuarkusPropertyTest.java
+++ b/src/test/java/org/openrewrite/quarkus/AddQuarkusPropertyTest.java
@@ -19,8 +19,6 @@ import org.junit.jupiter.api.Test;
 import org.openrewrite.DocumentExample;
 import org.openrewrite.test.RewriteTest;
 
-import java.util.List;
-
 import static org.openrewrite.properties.Assertions.properties;
 import static org.openrewrite.yaml.Assertions.yaml;
 
@@ -30,7 +28,7 @@ class AddQuarkusPropertyTest implements RewriteTest {
     @Test
     void addNestedIntoExisting() {
         rewriteRun(
-          spec -> spec.recipe(new AddQuarkusProperty("quarkus.http.port", "9090", null, null, List.of("*"))),
+          spec -> spec.recipe(new AddQuarkusProperty("quarkus.http.port", "9090", null, null, null)),
           //language=properties
           properties(
             """
@@ -39,7 +37,8 @@ class AddQuarkusPropertyTest implements RewriteTest {
             """
               quarkus.http.root-path=/api
               quarkus.http.port=9090
-              """
+              """,
+            spec -> spec.path("src/main/resources/application.properties")
           ),
           //language=yaml
           yaml(
@@ -53,7 +52,8 @@ class AddQuarkusPropertyTest implements RewriteTest {
                 http:
                   root-path: /api
                   port: 9090
-              """
+              """,
+            spec -> spec.path("src/main/resources/application.yaml")
           )
         );
     }
@@ -61,7 +61,7 @@ class AddQuarkusPropertyTest implements RewriteTest {
     @Test
     void addPropertyToRoot() {
         rewriteRun(
-          spec -> spec.recipe(new AddQuarkusProperty("fred", "fred", null, null, List.of("*"))),
+          spec -> spec.recipe(new AddQuarkusProperty("fred", "fred", null, null, null)),
           //language=properties
           properties(
             """
@@ -70,7 +70,8 @@ class AddQuarkusPropertyTest implements RewriteTest {
             """
               quarkus.http.port=9090
               fred=fred
-              """
+              """,
+            spec -> spec.path("src/main/resources/application.properties")
           ),
           //language=yaml
           yaml(
@@ -84,7 +85,8 @@ class AddQuarkusPropertyTest implements RewriteTest {
                 http:
                   root-path: /api
               fred: fred
-              """
+              """,
+            spec -> spec.path("src/main/resources/application.yaml")
           )
         );
     }
@@ -92,7 +94,7 @@ class AddQuarkusPropertyTest implements RewriteTest {
     @Test
     void addPropertyToRootWithProfile() {
         rewriteRun(
-          spec -> spec.recipe(new AddQuarkusProperty("fred", "fred", null, "dev", List.of("*"))),
+          spec -> spec.recipe(new AddQuarkusProperty("fred", "fred", null, "dev", null)),
           //language=properties
           properties(
             """
@@ -101,7 +103,8 @@ class AddQuarkusPropertyTest implements RewriteTest {
             """
               quarkus.http.port=9090
               %dev.fred=fred
-              """
+              """,
+            spec -> spec.path("src/main/resources/application.properties")
           ),
           //language=yaml
           yaml(
@@ -116,7 +119,8 @@ class AddQuarkusPropertyTest implements RewriteTest {
                   root-path: /api
               "%dev":
                 fred: fred
-              """
+              """,
+            spec -> spec.path("src/main/resources/application.yaml")
           )
         );
     }
@@ -124,13 +128,14 @@ class AddQuarkusPropertyTest implements RewriteTest {
     @Test
     void propertyAlreadyExists() {
         rewriteRun(
-          spec -> spec.recipe(new AddQuarkusProperty("fred", "fred", null, null, List.of("*"))),
+          spec -> spec.recipe(new AddQuarkusProperty("fred", "fred", null, null, null)),
           //language=properties
           properties(
             """
               quarkus.http.port=9090
               fred=doNotChangeThis
-              """
+              """,
+            spec -> spec.path("src/main/resources/application.properties")
           ),
           //language=yaml
           yaml(
@@ -139,7 +144,8 @@ class AddQuarkusPropertyTest implements RewriteTest {
                 http:
                   port: 9090
               fred: doNotChangeThis
-              """
+              """,
+            spec -> spec.path("src/main/resources/application.yaml")
           )
         );
     }
@@ -147,7 +153,7 @@ class AddQuarkusPropertyTest implements RewriteTest {
     @Test
     void addPropertyWithComment() {
         rewriteRun(
-          spec -> spec.recipe(new AddQuarkusProperty("quarkus.http.root-path", "/api", "This property was added", null, List.of("*"))),
+          spec -> spec.recipe(new AddQuarkusProperty("quarkus.http.root-path", "/api", "This property was added", null, null)),
           //language=properties
           properties(
             """
@@ -157,7 +163,8 @@ class AddQuarkusPropertyTest implements RewriteTest {
               quarkus.http.port=9090
               # This property was added
               quarkus.http.root-path=/api
-              """
+              """,
+            spec -> spec.path("src/main/resources/application.properties")
           ),
           //language=yaml
           yaml(
@@ -172,7 +179,8 @@ class AddQuarkusPropertyTest implements RewriteTest {
                   port: 9090
                   # This property was added
                   root-path: /api
-              """
+              """,
+            spec -> spec.path("src/main/resources/application.yaml")
           )
         );
     }
@@ -180,7 +188,8 @@ class AddQuarkusPropertyTest implements RewriteTest {
     @Test
     void makeChangeToMatchingFiles() {
         rewriteRun(
-          spec -> spec.recipe(new AddQuarkusProperty("quarkus.http.root-path", "/api", "This property was added", null, List.of("**/application.properties", "**/application.yml"))),
+          spec -> spec.recipe(new AddQuarkusProperty("quarkus.http.root-path", "/api", "This property was added", null, null)),
+          properties("# Sample empty properties file", s -> s.path("src/main/resources/test.properties")),
           //language=properties
           properties(
             """
@@ -215,7 +224,7 @@ class AddQuarkusPropertyTest implements RewriteTest {
     @Test
     void doNotChangeToFilesThatDoNotMatch() {
         rewriteRun(
-          spec -> spec.recipe(new AddQuarkusProperty("quarkus.http.root-path", "/api", null, null, List.of("**/application.properties", "**/application.yml"))),
+          spec -> spec.recipe(new AddQuarkusProperty("quarkus.http.root-path", "/api", null, null, null)),
           properties(
             //language=properties
             """

--- a/src/test/java/org/openrewrite/quarkus/ChangeQuarkusPropertyKeyTest.java
+++ b/src/test/java/org/openrewrite/quarkus/ChangeQuarkusPropertyKeyTest.java
@@ -18,7 +18,6 @@ package org.openrewrite.quarkus;
 import org.intellij.lang.annotations.Language;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
-import org.openrewrite.Recipe;
 import org.openrewrite.test.RewriteTest;
 
 import static org.openrewrite.properties.Assertions.properties;
@@ -41,13 +40,11 @@ class ChangeQuarkusPropertyKeyTest {
 
         @Test
         void noChangesIfKeyNotFound() {
-            Recipe recipe = new ChangeQuarkusPropertyKey(
-              "quarkus\\.foo",
-              "quarkus\\.bar",
-              null, null, null, null);
-
             rewriteRun(
-              spec -> spec.recipe(recipe),
+              spec -> spec.recipe(new ChangeQuarkusPropertyKey(
+                "quarkus\\.foo",
+                "quarkus\\.bar",
+                null, null, null, null)),
               properties(sourceProperties, spec -> spec.path("src/main/resources/application.properties"))
             );
         }
@@ -65,13 +62,11 @@ class ChangeQuarkusPropertyKeyTest {
               %staging,prod.quarkus.hibernate-search-orm."unitname".automatic-indexing.synchronization.strategy=async
               """;
 
-            Recipe recipe = new ChangeQuarkusPropertyKey(
-              "quarkus\\.hibernate-search-orm(\\..*)?\\.automatic-indexing\\.synchronization\\.strategy",
-              "quarkus.hibernate-search-orm$1.indexing.plan.synchronization.strategy",
-              null, null, null, null);
-
             rewriteRun(
-              spec -> spec.recipe(recipe),
+              spec -> spec.recipe(new ChangeQuarkusPropertyKey(
+                "quarkus\\.hibernate-search-orm(\\..*)?\\.automatic-indexing\\.synchronization\\.strategy",
+                "quarkus.hibernate-search-orm$1.indexing.plan.synchronization.strategy",
+                null, null, false, null)),
               properties(sourceProperties, after, spec -> spec.path("src/main/resources/application.properties"))
             );
         }
@@ -91,13 +86,11 @@ class ChangeQuarkusPropertyKeyTest {
               %staging.quarkus.hibernate-search-orm.automatic-indexing.synchronization.strategy=async
               """;
 
-            Recipe recipe = new ChangeQuarkusPropertyKey(
-              "quarkus\\.hibernate-search-orm(\\..*)?\\.automatic-indexing\\.synchronization\\.strategy",
-              "quarkus.hibernate-search-orm$1.indexing.plan.synchronization.strategy",
-              null, "prod", false, null);
-
             rewriteRun(
-              spec -> spec.recipe(recipe),
+              spec -> spec.recipe(new ChangeQuarkusPropertyKey(
+                "quarkus\\.hibernate-search-orm(\\..*)?\\.automatic-indexing\\.synchronization\\.strategy",
+                "quarkus.hibernate-search-orm$1.indexing.plan.synchronization.strategy",
+                null, "prod", false, null)),
               properties(sourceProperties, after, spec -> spec.path("src/main/resources/application.properties"))
             );
         }
@@ -115,13 +108,11 @@ class ChangeQuarkusPropertyKeyTest {
               %staging,prod.quarkus.hibernate-search-orm."unitname".indexing.plan.synchronization.strategy=async
               """;
 
-            Recipe recipe = new ChangeQuarkusPropertyKey(
-              "quarkus\\.hibernate-search-orm(\\..*)?\\.automatic-indexing\\.synchronization\\.strategy",
-              "quarkus.hibernate-search-orm$1.indexing.plan.synchronization.strategy",
-              null, null, true, null);
-
             rewriteRun(
-              spec -> spec.recipe(recipe),
+              spec -> spec.recipe(new ChangeQuarkusPropertyKey(
+                "quarkus\\.hibernate-search-orm(\\..*)?\\.automatic-indexing\\.synchronization\\.strategy",
+                "quarkus.hibernate-search-orm$1.indexing.plan.synchronization.strategy",
+                null, null, true, null)),
               properties(sourceProperties, after, spec -> spec.path("src/main/resources/application.properties"))
             );
         }
@@ -164,13 +155,11 @@ class ChangeQuarkusPropertyKeyTest {
 
         @Test
         void noChangesIfKeyNotFound() {
-            Recipe recipe = new ChangeQuarkusPropertyKey(
-              "quarkus\\.foo",
-              "quarkus\\.bar",
-              null, null, null, null);
-
             rewriteRun(
-              spec -> spec.recipe(recipe),
+              spec -> spec.recipe(new ChangeQuarkusPropertyKey(
+                "quarkus\\.foo",
+                "quarkus\\.bar",
+                null, null, null, null)),
               yaml(sourceYaml, spec -> spec.path("src/main/resources/application.yaml"))
             );
         }
@@ -212,13 +201,11 @@ class ChangeQuarkusPropertyKeyTest {
                           strategy: async
               """;
 
-            Recipe recipe = new ChangeQuarkusPropertyKey(
-              "quarkus\\.hibernate-search-orm(\\..*)?\\.automatic-indexing\\.synchronization\\.strategy",
-              "quarkus.hibernate-search-orm$1.indexing.plan.synchronization.strategy",
-              null, null, null, null);
-
             rewriteRun(
-              spec -> spec.recipe(recipe),
+              spec -> spec.recipe(new ChangeQuarkusPropertyKey(
+                "quarkus\\.hibernate-search-orm(\\..*)?\\.automatic-indexing\\.synchronization\\.strategy",
+                "quarkus.hibernate-search-orm$1.indexing.plan.synchronization.strategy",
+                null, null, false, null)),
               yaml(sourceYaml, after, spec -> spec.path("src/main/resources/application.yaml"))
             );
         }
@@ -269,13 +256,11 @@ class ChangeQuarkusPropertyKeyTest {
                           strategy: async
               """;
 
-            Recipe recipe = new ChangeQuarkusPropertyKey(
-              "quarkus\\.hibernate-search-orm(\\..*)?\\.automatic-indexing\\.synchronization\\.strategy",
-              "quarkus.hibernate-search-orm$1.indexing.plan.synchronization.strategy",
-              null, "prod", false, null);
-
             rewriteRun(
-              spec -> spec.recipe(recipe),
+              spec -> spec.recipe(new ChangeQuarkusPropertyKey(
+                "quarkus\\.hibernate-search-orm(\\..*)?\\.automatic-indexing\\.synchronization\\.strategy",
+                "quarkus.hibernate-search-orm$1.indexing.plan.synchronization.strategy",
+                null, "prod", false, null)),
               yaml(sourceYaml, after, spec -> spec.path("src/main/resources/application.yaml"))
             );
         }
@@ -286,30 +271,46 @@ class ChangeQuarkusPropertyKeyTest {
             String after = """
               quarkus:
                 hibernate-search-orm:
-                    unitname:
-                        indexing.plan.synchronization.strategy: read-sync
-                    indexing.plan.synchronization.strategy: read-sync
+                  indexing:
+                    plan:
+                      synchronization:
+                        strategy: read-sync
+                  unitname:
+                    indexing:
+                      plan:
+                        synchronization:
+                          strategy: read-sync
               '%dev':
                 quarkus:
                   hibernate-search-orm:
-                      unitname:
-                          indexing.plan.synchronization.strategy: sync
-                      indexing.plan.synchronization.strategy: sync
+                    indexing:
+                      plan:
+                        synchronization:
+                          strategy: sync
+                    unitname:
+                      indexing:
+                        plan:
+                          synchronization:
+                            strategy: sync
               '%staging,prod':
                 quarkus:
                   hibernate-search-orm:
-                      unitname:
-                          indexing.plan.synchronization.strategy: async
-                      indexing.plan.synchronization.strategy: async
+                    indexing:
+                      plan:
+                        synchronization:
+                          strategy: async
+                    unitname:
+                      indexing:
+                        plan:
+                          synchronization:
+                            strategy: async
               """;
 
-            Recipe recipe = new ChangeQuarkusPropertyKey(
-              "quarkus\\.hibernate-search-orm(\\..*)?\\.automatic-indexing\\.synchronization\\.strategy",
-              "quarkus.hibernate-search-orm$1.indexing.plan.synchronization.strategy",
-              null, null, true, null);
-
             rewriteRun(
-              spec -> spec.recipe(recipe).expectedCyclesThatMakeChanges(2),
+              spec -> spec.recipe(new ChangeQuarkusPropertyKey(
+                "quarkus\\.hibernate-search-orm(\\..*)?\\.automatic-indexing\\.synchronization\\.strategy",
+                "quarkus.hibernate-search-orm$1.indexing.plan.synchronization.strategy",
+                null, null, true, null)),
               yaml(sourceYaml, after, spec -> spec.path("src/main/resources/application.yaml"))
             );
         }

--- a/src/test/java/org/openrewrite/quarkus/ChangeQuarkusPropertyKeyTest.java
+++ b/src/test/java/org/openrewrite/quarkus/ChangeQuarkusPropertyKeyTest.java
@@ -42,19 +42,9 @@ class ChangeQuarkusPropertyKeyTest {
 
         @Test
         void noChangesIfPropertyNotFound() {
-            Recipe recipe = new ChangeQuarkusPropertyKey(
-              "quarkus\\.foo",
-              "quarkus\\.bar",
-              null,
-              null,
-              null,
-              null
-            );
+            Recipe recipe = new ChangeQuarkusPropertyKey("quarkus\\.foo", "quarkus\\.bar", null, null, null, null);
 
-            rewriteRun(
-              spec -> spec.recipe(recipe),
-              properties(sourceProperties, spec -> spec.path("src/main/resources/application.properties"))
-            );
+            rewriteRun(spec -> spec.recipe(recipe), properties(sourceProperties, spec -> spec.path("src/main/resources/application.properties")));
         }
 
         @Test
@@ -70,19 +60,9 @@ class ChangeQuarkusPropertyKeyTest {
               %staging,prod.quarkus.hibernate-search-orm."unitname".automatic-indexing.synchronization.strategy=test
               """;
 
-            Recipe recipe = new ChangeQuarkusPropertyKey(
-              "quarkus\\.hibernate-search-orm(\\..*)?\\.automatic-indexing\\.synchronization\\.strategy",
-              "quarkus.hibernate-search-orm$1.indexing.plan.synchronization.strategy",
-              null,
-              null,
-              null,
-              null
-            );
+            Recipe recipe = new ChangeQuarkusPropertyKey("quarkus\\.hibernate-search-orm(\\..*)?\\.automatic-indexing\\.synchronization\\.strategy", "quarkus.hibernate-search-orm$1.indexing.plan.synchronization.strategy", null, null, null, null);
 
-            rewriteRun(
-              spec -> spec.recipe(recipe),
-              properties(sourceProperties, after, spec -> spec.path("src/main/resources/application.properties"))
-            );
+            rewriteRun(spec -> spec.recipe(recipe), properties(sourceProperties, after, spec -> spec.path("src/main/resources/application.properties")));
         }
 
         @Test
@@ -100,19 +80,9 @@ class ChangeQuarkusPropertyKeyTest {
               %staging.quarkus.hibernate-search-orm.automatic-indexing.synchronization.strategy=test
               """;
 
-            Recipe recipe = new ChangeQuarkusPropertyKey(
-              "quarkus\\.hibernate-search-orm(\\..*)?\\.automatic-indexing\\.synchronization\\.strategy",
-              "quarkus.hibernate-search-orm$1.indexing.plan.synchronization.strategy",
-              null,
-              "prod",
-              false,
-              null
-            );
+            Recipe recipe = new ChangeQuarkusPropertyKey("quarkus\\.hibernate-search-orm(\\..*)?\\.automatic-indexing\\.synchronization\\.strategy", "quarkus.hibernate-search-orm$1.indexing.plan.synchronization.strategy", null, "prod", false, null);
 
-            rewriteRun(
-              spec -> spec.recipe(recipe),
-              properties(sourceProperties, after, spec -> spec.path("src/main/resources/application.properties"))
-            );
+            rewriteRun(spec -> spec.recipe(recipe), properties(sourceProperties, after, spec -> spec.path("src/main/resources/application.properties")));
         }
 
         @Test
@@ -128,19 +98,9 @@ class ChangeQuarkusPropertyKeyTest {
               %staging,prod.quarkus.hibernate-search-orm."unitname".indexing.plan.synchronization.strategy=test
               """;
 
-            Recipe recipe = new ChangeQuarkusPropertyKey(
-              "quarkus\\.hibernate-search-orm(\\..*)?\\.automatic-indexing\\.synchronization\\.strategy",
-              "quarkus.hibernate-search-orm$1.indexing.plan.synchronization.strategy",
-              null,
-              null,
-              true,
-              null
-            );
+            Recipe recipe = new ChangeQuarkusPropertyKey("quarkus\\.hibernate-search-orm(\\..*)?\\.automatic-indexing\\.synchronization\\.strategy", "quarkus.hibernate-search-orm$1.indexing.plan.synchronization.strategy", null, null, true, null);
 
-            rewriteRun(
-              spec -> spec.recipe(recipe),
-              properties(sourceProperties, after, spec -> spec.path("src/main/resources/application.properties"))
-            );
+            rewriteRun(spec -> spec.recipe(recipe), properties(sourceProperties, after, spec -> spec.path("src/main/resources/application.properties")));
         }
     }
 
@@ -181,23 +141,12 @@ class ChangeQuarkusPropertyKeyTest {
 
         @Test
         void noChangesIfPropertyNotFound() {
-            Recipe recipe = new ChangeQuarkusPropertyKey(
-              "quarkus\\.foo",
-              "quarkus\\.bar",
-              null,
-              null,
-              null,
-              null
-            );
+            Recipe recipe = new ChangeQuarkusPropertyKey("quarkus\\.foo", "quarkus\\.bar", null, null, null, null);
 
-            rewriteRun(
-              spec -> spec.recipe(recipe),
-              yaml(sourceYaml, spec -> spec.path("src/main/resources/application.yaml"))
-            );
+            rewriteRun(spec -> spec.recipe(recipe), yaml(sourceYaml, spec -> spec.path("src/main/resources/application.yaml")));
         }
 
         @Test
-        @Disabled("Pending implementation")
         void changeDefaultProfile() {
             @Language("yml")
             String after = """
@@ -234,26 +183,14 @@ class ChangeQuarkusPropertyKeyTest {
                           strategy: test
               """;
 
-            Recipe recipe = new ChangeQuarkusPropertyKey(
-              "quarkus\\.hibernate-search-orm(\\..*)?\\.automatic-indexing\\.synchronization\\.strategy",
-              "quarkus.hibernate-search-orm$1.indexing.plan.synchronization.strategy",
-              null,
-              null,
-              null,
-              null
-            );
+            Recipe recipe = new ChangeQuarkusPropertyKey("quarkus\\.hibernate-search-orm(\\..*)?\\.automatic-indexing\\.synchronization\\.strategy", "quarkus.hibernate-search-orm$1.indexing.plan.synchronization.strategy", null, null, null, null);
 
-            rewriteRun(
-              spec -> spec.recipe(recipe),
-              yaml(sourceYaml, after, spec -> spec.path("src/main/resources/application.yaml"))
-            );
+            rewriteRun(spec -> spec.recipe(recipe), yaml(sourceYaml, after, spec -> spec.path("src/main/resources/application.yaml")));
         }
 
         @Test
-        @Disabled("Pending implementation")
         void changeNamedProfile() {
-            @Language("yml")
-            String after = """
+            @Language("yml") String after = """
               quarkus:
                 hibernate-search-orm:
                   automatic-indexing:
@@ -273,7 +210,19 @@ class ChangeQuarkusPropertyKeyTest {
                       automatic-indexing:
                         synchronization:
                           strategy: test
-              '%staging,prod':
+              '%prod':
+                quarkus:
+                  hibernate-search-orm:
+                    indexing:
+                      plan:
+                        synchronization:
+                          strategy: test
+                    unitname:
+                      indexing:
+                        plan:
+                          synchronization:
+                            strategy: test
+              '%staging':
                 quarkus:
                   hibernate-search-orm:
                     automatic-indexing:
@@ -285,71 +234,55 @@ class ChangeQuarkusPropertyKeyTest {
                           strategy: test
               """;
 
-            Recipe recipe = new ChangeQuarkusPropertyKey(
-              "quarkus\\.hibernate-search-orm(\\..*)?\\.automatic-indexing\\.synchronization\\.strategy",
-              "quarkus.hibernate-search-orm$1.indexing.plan.synchronization.strategy",
-              null,
-              "prod",
-              false,
-              null
-            );
+            Recipe recipe = new ChangeQuarkusPropertyKey("quarkus\\.hibernate-search-orm(\\..*)?\\.automatic-indexing\\.synchronization\\.strategy", "quarkus.hibernate-search-orm$1.indexing.plan.synchronization.strategy", null, "prod", false, null);
 
-            rewriteRun(
-              spec -> spec.recipe(recipe),
-              yaml(sourceYaml, after, spec -> spec.path("src/main/resources/application.yaml"))
-            );
+            rewriteRun(spec -> spec.recipe(recipe), yaml(sourceYaml, after, spec -> spec.path("src/main/resources/application.yaml")));
         }
 
         @Test
-        @Disabled("Pending implementation")
         void changeAllProfiles() {
             @Language("yml")
             String after = """
-               quarkus:
-                 hibernate-search-orm:
-                   automatic-indexing:
-                     synchronization:
-                       strategy: test
-                   unitname:
-                     automatic-indexing:
-                       synchronization:
-                         strategy: test
-               '%dev':
-                 quarkus:
-                   hibernate-search-orm:
-                     automatic-indexing:
-                       synchronization:
-                         strategy: test
-                     unitname:
-                       automatic-indexing:
-                         synchronization:
-                           strategy: test
-               '%staging,prod':
-                 quarkus:
-                   hibernate-search-orm:
-                     automatic-indexing:
-                       synchronization:
-                         strategy: test
-                     unitname:
-                       automatic-indexing:
-                         synchronization:
-                           strategy: test
+              quarkus:
+                hibernate-search-orm:
+                  indexing:
+                    plan:
+                      synchronization:
+                        strategy: test
+                  unitname:
+                    indexing:
+                      plan:
+                        synchronization:
+                          strategy: test
+              '%dev':
+                quarkus:
+                  hibernate-search-orm:
+                    indexing:
+                      plan:
+                        synchronization:
+                          strategy: test
+                    unitname:
+                      indexing:
+                        plan:
+                          synchronization:
+                            strategy: test
+              '%staging,prod':
+                quarkus:
+                  hibernate-search-orm:
+                    indexing:
+                      plan:
+                        synchronization:
+                          strategy: test
+                    unitname:
+                      indexing:
+                        plan:
+                          synchronization:
+                            strategy: test
               """;
 
+            Recipe recipe = new ChangeQuarkusPropertyKey("quarkus\\.hibernate-search-orm(\\..*)?\\.automatic-indexing\\.synchronization\\.strategy", "quarkus.hibernate-search-orm$1.indexing.plan.synchronization.strategy", null, null, true, null);
 
-            Recipe recipe = new ChangeQuarkusPropertyKey(
-              "quarkus\\.hibernate-search-orm(\\..*)?\\.automatic-indexing\\.synchronization\\.strategy",
-              "quarkus.hibernate-search-orm$1.indexing.plan.synchronization.strategy",
-              null,
-              null,
-              true,
-              null
-            );
-
-            rewriteRun(
-              spec -> spec.recipe(recipe),
-              yaml(sourceYaml, after, spec -> spec.path("src/main/resources/application.yaml"))
-            );
+            rewriteRun(spec -> spec.recipe(recipe), yaml(sourceYaml, after, spec -> spec.path("src/main/resources/application.yaml")));
         }
     }
 }

--- a/src/test/java/org/openrewrite/quarkus/ChangeQuarkusPropertyKeyTest.java
+++ b/src/test/java/org/openrewrite/quarkus/ChangeQuarkusPropertyKeyTest.java
@@ -245,15 +245,15 @@ class ChangeQuarkusPropertyKeyTest {
             String after = """
               quarkus:
                 hibernate-search-orm:
-                  indexing:
-                    plan:
-                      synchronization:
-                        strategy: test
                   unitname:
                     indexing:
                       plan:
                         synchronization:
                           strategy: test
+                  indexing:
+                    plan:
+                      synchronization:
+                        strategy: test
               '%dev':
                 quarkus:
                   hibernate-search-orm:

--- a/src/test/java/org/openrewrite/quarkus/ChangeQuarkusPropertyKeyTest.java
+++ b/src/test/java/org/openrewrite/quarkus/ChangeQuarkusPropertyKeyTest.java
@@ -282,7 +282,8 @@ class ChangeQuarkusPropertyKeyTest {
 
             Recipe recipe = new ChangeQuarkusPropertyKey("quarkus\\.hibernate-search-orm(\\..*)?\\.automatic-indexing\\.synchronization\\.strategy", "quarkus.hibernate-search-orm$1.indexing.plan.synchronization.strategy", null, null, true, null);
 
-            rewriteRun(spec -> spec.recipe(recipe), yaml(sourceYaml, after, spec -> spec.path("src/main/resources/application.yaml")));
+            rewriteRun(spec -> spec.recipe(recipe).expectedCyclesThatMakeChanges(2),
+              yaml(sourceYaml, after, spec -> spec.path("src/main/resources/application.yaml")));
         }
     }
 }

--- a/src/test/java/org/openrewrite/quarkus/ChangeQuarkusPropertyKeyTest.java
+++ b/src/test/java/org/openrewrite/quarkus/ChangeQuarkusPropertyKeyTest.java
@@ -1,0 +1,355 @@
+/*
+ * Copyright 2023 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.quarkus;
+
+import org.intellij.lang.annotations.Language;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.openrewrite.Recipe;
+import org.openrewrite.test.RewriteTest;
+
+import static org.openrewrite.properties.Assertions.properties;
+import static org.openrewrite.yaml.Assertions.yaml;
+
+class ChangeQuarkusPropertyKeyTest {
+
+    @Nested
+    class Properties implements RewriteTest {
+        @Language("properties")
+        private final String sourceProperties = """
+          quarkus.hibernate-search-orm.automatic-indexing.synchronization.strategy=test
+          %dev.quarkus.hibernate-search-orm.automatic-indexing.synchronization.strategy=test
+          %staging,prod.quarkus.hibernate-search-orm.automatic-indexing.synchronization.strategy=test
+                
+          quarkus.hibernate-search-orm."unitname".automatic-indexing.synchronization.strategy=test
+          %dev.quarkus.hibernate-search-orm."unitname".automatic-indexing.synchronization.strategy=test
+          %staging,prod.quarkus.hibernate-search-orm."unitname".automatic-indexing.synchronization.strategy=test
+          """;
+
+        @Test
+        void noChangesIfPropertyNotFound() {
+            Recipe recipe = new ChangeQuarkusPropertyKey(
+              "quarkus\\.foo",
+              "quarkus\\.bar",
+              null,
+              null,
+              null,
+              null
+            );
+
+            rewriteRun(
+              spec -> spec.recipe(recipe),
+              properties(sourceProperties, spec -> spec.path("src/main/resources/application.properties"))
+            );
+        }
+
+        @Test
+        void changeDefaultProfile() {
+            @Language("properties")
+            String after = """
+              quarkus.hibernate-search-orm.indexing.plan.synchronization.strategy=test
+              %dev.quarkus.hibernate-search-orm.automatic-indexing.synchronization.strategy=test
+              %staging,prod.quarkus.hibernate-search-orm.automatic-indexing.synchronization.strategy=test
+                            
+              quarkus.hibernate-search-orm."unitname".indexing.plan.synchronization.strategy=test
+              %dev.quarkus.hibernate-search-orm."unitname".automatic-indexing.synchronization.strategy=test
+              %staging,prod.quarkus.hibernate-search-orm."unitname".automatic-indexing.synchronization.strategy=test
+              """;
+
+            Recipe recipe = new ChangeQuarkusPropertyKey(
+              "quarkus\\.hibernate-search-orm(\\..*)?\\.automatic-indexing\\.synchronization\\.strategy",
+              "quarkus.hibernate-search-orm$1.indexing.plan.synchronization.strategy",
+              null,
+              null,
+              null,
+              null
+            );
+
+            rewriteRun(
+              spec -> spec.recipe(recipe),
+              properties(sourceProperties, after, spec -> spec.path("src/main/resources/application.properties"))
+            );
+        }
+
+        @Test
+        void changeNamedProfile() {
+            @Language("properties")
+            String after = """
+              quarkus.hibernate-search-orm.automatic-indexing.synchronization.strategy=test
+              %dev.quarkus.hibernate-search-orm.automatic-indexing.synchronization.strategy=test
+                            
+              quarkus.hibernate-search-orm."unitname".automatic-indexing.synchronization.strategy=test
+              %dev.quarkus.hibernate-search-orm."unitname".automatic-indexing.synchronization.strategy=test
+              %prod.quarkus.hibernate-search-orm."unitname".indexing.plan.synchronization.strategy=test
+              %staging.quarkus.hibernate-search-orm."unitname".automatic-indexing.synchronization.strategy=test
+              %prod.quarkus.hibernate-search-orm.indexing.plan.synchronization.strategy=test
+              %staging.quarkus.hibernate-search-orm.automatic-indexing.synchronization.strategy=test
+              """;
+
+            Recipe recipe = new ChangeQuarkusPropertyKey(
+              "quarkus\\.hibernate-search-orm(\\..*)?\\.automatic-indexing\\.synchronization\\.strategy",
+              "quarkus.hibernate-search-orm$1.indexing.plan.synchronization.strategy",
+              null,
+              "prod",
+              false,
+              null
+            );
+
+            rewriteRun(
+              spec -> spec.recipe(recipe),
+              properties(sourceProperties, after, spec -> spec.path("src/main/resources/application.properties"))
+            );
+        }
+
+        @Test
+        void changeAllProfiles() {
+            @Language("properties")
+            String after = """
+              quarkus.hibernate-search-orm.indexing.plan.synchronization.strategy=test
+              %dev.quarkus.hibernate-search-orm.indexing.plan.synchronization.strategy=test
+              %staging,prod.quarkus.hibernate-search-orm.indexing.plan.synchronization.strategy=test
+                            
+              quarkus.hibernate-search-orm."unitname".indexing.plan.synchronization.strategy=test
+              %dev.quarkus.hibernate-search-orm."unitname".indexing.plan.synchronization.strategy=test
+              %staging,prod.quarkus.hibernate-search-orm."unitname".indexing.plan.synchronization.strategy=test
+              """;
+
+            Recipe recipe = new ChangeQuarkusPropertyKey(
+              "quarkus\\.hibernate-search-orm(\\..*)?\\.automatic-indexing\\.synchronization\\.strategy",
+              "quarkus.hibernate-search-orm$1.indexing.plan.synchronization.strategy",
+              null,
+              null,
+              true,
+              null
+            );
+
+            rewriteRun(
+              spec -> spec.recipe(recipe),
+              properties(sourceProperties, after, spec -> spec.path("src/main/resources/application.properties"))
+            );
+        }
+    }
+
+    @Nested
+    class Yaml implements RewriteTest {
+        @Language("yml")
+        private final String sourceYaml = """
+          quarkus:
+            hibernate-search-orm:
+              automatic-indexing:
+                synchronization:
+                  strategy: test
+              unitname:
+                automatic-indexing:
+                  synchronization:
+                    strategy: test
+          '%dev':
+            quarkus:
+              hibernate-search-orm:
+                automatic-indexing:
+                  synchronization:
+                    strategy: test
+                unitname:
+                  automatic-indexing:
+                    synchronization:
+                      strategy: test
+          '%staging,prod':
+            quarkus:
+              hibernate-search-orm:
+                automatic-indexing:
+                  synchronization:
+                    strategy: test
+                unitname:
+                  automatic-indexing:
+                    synchronization:
+                      strategy: test
+          """;
+
+        @Test
+        void noChangesIfPropertyNotFound() {
+            Recipe recipe = new ChangeQuarkusPropertyKey(
+              "quarkus\\.foo",
+              "quarkus\\.bar",
+              null,
+              null,
+              null,
+              null
+            );
+
+            rewriteRun(
+              spec -> spec.recipe(recipe),
+              yaml(sourceYaml, spec -> spec.path("src/main/resources/application.yaml"))
+            );
+        }
+
+        @Test
+        @Disabled("Pending implementation")
+        void changeDefaultProfile() {
+            @Language("yml")
+            String after = """
+              quarkus:
+                hibernate-search-orm:
+                  indexing:
+                    plan:
+                      synchronization:
+                        strategy: test
+                  unitname:
+                    indexing:
+                      plan:
+                        synchronization:
+                          strategy: test
+              '%dev':
+                quarkus:
+                  hibernate-search-orm:
+                    automatic-indexing:
+                      synchronization:
+                        strategy: test
+                    unitname:
+                      automatic-indexing:
+                        synchronization:
+                          strategy: test
+              '%staging,prod':
+                quarkus:
+                  hibernate-search-orm:
+                    automatic-indexing:
+                      synchronization:
+                        strategy: test
+                    unitname:
+                      automatic-indexing:
+                        synchronization:
+                          strategy: test
+              """;
+
+            Recipe recipe = new ChangeQuarkusPropertyKey(
+              "quarkus\\.hibernate-search-orm(\\..*)?\\.automatic-indexing\\.synchronization\\.strategy",
+              "quarkus.hibernate-search-orm$1.indexing.plan.synchronization.strategy",
+              null,
+              null,
+              null,
+              null
+            );
+
+            rewriteRun(
+              spec -> spec.recipe(recipe),
+              yaml(sourceYaml, after, spec -> spec.path("src/main/resources/application.yaml"))
+            );
+        }
+
+        @Test
+        @Disabled("Pending implementation")
+        void changeNamedProfile() {
+            @Language("yml")
+            String after = """
+              quarkus:
+                hibernate-search-orm:
+                  automatic-indexing:
+                    synchronization:
+                      strategy: test
+                  unitname:
+                    automatic-indexing:
+                      synchronization:
+                        strategy: test
+              '%dev':
+                quarkus:
+                  hibernate-search-orm:
+                    automatic-indexing:
+                      synchronization:
+                        strategy: test
+                    unitname:
+                      automatic-indexing:
+                        synchronization:
+                          strategy: test
+              '%staging,prod':
+                quarkus:
+                  hibernate-search-orm:
+                    automatic-indexing:
+                      synchronization:
+                        strategy: test
+                    unitname:
+                      automatic-indexing:
+                        synchronization:
+                          strategy: test
+              """;
+
+            Recipe recipe = new ChangeQuarkusPropertyKey(
+              "quarkus\\.hibernate-search-orm(\\..*)?\\.automatic-indexing\\.synchronization\\.strategy",
+              "quarkus.hibernate-search-orm$1.indexing.plan.synchronization.strategy",
+              null,
+              "prod",
+              false,
+              null
+            );
+
+            rewriteRun(
+              spec -> spec.recipe(recipe),
+              yaml(sourceYaml, after, spec -> spec.path("src/main/resources/application.yaml"))
+            );
+        }
+
+        @Test
+        @Disabled("Pending implementation")
+        void changeAllProfiles() {
+            @Language("yml")
+            String after = """
+               quarkus:
+                 hibernate-search-orm:
+                   automatic-indexing:
+                     synchronization:
+                       strategy: test
+                   unitname:
+                     automatic-indexing:
+                       synchronization:
+                         strategy: test
+               '%dev':
+                 quarkus:
+                   hibernate-search-orm:
+                     automatic-indexing:
+                       synchronization:
+                         strategy: test
+                     unitname:
+                       automatic-indexing:
+                         synchronization:
+                           strategy: test
+               '%staging,prod':
+                 quarkus:
+                   hibernate-search-orm:
+                     automatic-indexing:
+                       synchronization:
+                         strategy: test
+                     unitname:
+                       automatic-indexing:
+                         synchronization:
+                           strategy: test
+              """;
+
+
+            Recipe recipe = new ChangeQuarkusPropertyKey(
+              "quarkus\\.hibernate-search-orm(\\..*)?\\.automatic-indexing\\.synchronization\\.strategy",
+              "quarkus.hibernate-search-orm$1.indexing.plan.synchronization.strategy",
+              null,
+              null,
+              true,
+              null
+            );
+
+            rewriteRun(
+              spec -> spec.recipe(recipe),
+              yaml(sourceYaml, after, spec -> spec.path("src/main/resources/application.yaml"))
+            );
+        }
+    }
+}

--- a/src/test/java/org/openrewrite/quarkus/ChangeQuarkusPropertyKeyTest.java
+++ b/src/test/java/org/openrewrite/quarkus/ChangeQuarkusPropertyKeyTest.java
@@ -16,7 +16,6 @@
 package org.openrewrite.quarkus;
 
 import org.intellij.lang.annotations.Language;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.openrewrite.Recipe;
@@ -280,10 +279,12 @@ class ChangeQuarkusPropertyKeyTest {
                             strategy: test
               """;
 
-            Recipe recipe = new ChangeQuarkusPropertyKey("quarkus\\.hibernate-search-orm(\\..*)?\\.automatic-indexing\\.synchronization\\.strategy", "quarkus.hibernate-search-orm$1.indexing.plan.synchronization.strategy", null, null, true, null);
+            Recipe recipe = new ChangeQuarkusPropertyKey(
+              "quarkus\\.hibernate-search-orm(\\..*)?\\.automatic-indexing\\.synchronization\\.strategy",
+              "quarkus.hibernate-search-orm$1.indexing.plan.synchronization.strategy",
+              null, null, true, null);
 
-            rewriteRun(spec -> spec.recipe(recipe).expectedCyclesThatMakeChanges(2),
-              yaml(sourceYaml, after, spec -> spec.path("src/main/resources/application.yaml")));
+            rewriteRun(spec -> spec.recipe(recipe), yaml(sourceYaml, after, spec -> spec.path("src/main/resources/application.yaml")));
         }
     }
 }

--- a/src/test/java/org/openrewrite/quarkus/ChangeQuarkusPropertyValueTest.java
+++ b/src/test/java/org/openrewrite/quarkus/ChangeQuarkusPropertyValueTest.java
@@ -18,7 +18,6 @@ package org.openrewrite.quarkus;
 import org.intellij.lang.annotations.Language;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
-import org.openrewrite.Recipe;
 import org.openrewrite.test.RewriteTest;
 
 import static org.openrewrite.properties.Assertions.properties;
@@ -67,7 +66,7 @@ class ChangeQuarkusPropertyValueTest implements RewriteTest {
               spec -> spec.recipe(new ChangeQuarkusPropertyValue(
                 "quarkus\\.hibernate-search-orm(\\..*)?\\.automatic-indexing\\.synchronization\\.strategy",
                 "write-sync",
-                null, null, null, null)),
+                null, null, false, null)),
               properties(sourceProperties, after, spec -> spec.path("src/main/resources/application.properties"))
             );
         }
@@ -204,7 +203,7 @@ class ChangeQuarkusPropertyValueTest implements RewriteTest {
               spec -> spec.recipe(new ChangeQuarkusPropertyValue(
                 "quarkus\\.hibernate-search-orm(\\..*)?\\.automatic-indexing\\.synchronization\\.strategy",
                 "write-sync",
-                null, null, null, null)),
+                null, null, false, null)),
               yaml(sourceYaml, after, spec -> spec.path("src/main/resources/application.yaml"))
             );
         }

--- a/src/test/java/org/openrewrite/quarkus/DeleteQuarkusPropertyTest.java
+++ b/src/test/java/org/openrewrite/quarkus/DeleteQuarkusPropertyTest.java
@@ -65,7 +65,7 @@ class DeleteQuarkusPropertyTest implements RewriteTest {
             rewriteRun(
               spec -> spec.recipe(new DeleteQuarkusProperty(
                 "quarkus\\.hibernate-search-orm(\\..*)?\\.automatic-indexing\\.synchronization\\.strategy",
-                null, null, null, null)),
+                null, null, false, null)),
               properties(sourceProperties, after, spec -> spec.path("src/main/resources/application.properties"))
             );
         }
@@ -160,8 +160,10 @@ class DeleteQuarkusPropertyTest implements RewriteTest {
 
         @Test
         void deleteValueOnDefaultProfileOnly() {
+            // intentional 2 blank lines because the compiler will remove the first one
             @Language("yml")
             String after = """
+
 
               '%dev':
                 quarkus:
@@ -188,7 +190,7 @@ class DeleteQuarkusPropertyTest implements RewriteTest {
             rewriteRun(
               spec -> spec.recipe(new DeleteQuarkusProperty(
                 "quarkus\\.hibernate-search-orm(\\..*)?\\.automatic-indexing\\.synchronization\\.strategy",
-                null, null, null, null)),
+                null, null, false, null)),
               yaml(sourceYaml, after, spec -> spec.path("src/main/resources/application.yaml"))
             );
         }

--- a/src/test/java/org/openrewrite/quarkus/search/FindQuarkusProfilesTest.java
+++ b/src/test/java/org/openrewrite/quarkus/search/FindQuarkusProfilesTest.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright 2023 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.quarkus.search;
+
+import org.intellij.lang.annotations.Language;
+import org.junit.jupiter.api.Test;
+import org.openrewrite.InMemoryExecutionContext;
+import org.openrewrite.properties.PropertiesParser;
+import org.openrewrite.properties.tree.Properties;
+import org.openrewrite.test.RecipeSpec;
+import org.openrewrite.test.RewriteTest;
+import org.openrewrite.yaml.YamlParser;
+import org.openrewrite.yaml.tree.Yaml;
+
+import static org.assertj.core.api.AssertionsForInterfaceTypes.assertThat;
+
+class FindQuarkusProfilesTest implements RewriteTest {
+
+    @Override
+    public void defaults(RecipeSpec spec) {
+        spec.recipe(new FindQuarkusProfiles()).executionContext(new InMemoryExecutionContext());
+    }
+
+    @Test
+    void propertiesFile() {
+        @Language("properties")
+        String source = """
+          quarkus.http.port=8080
+          %dev.quarkus.http.port=9090
+          %staging,prod.quarkus.http.root-path=/quarkus
+          """;
+
+        Properties.File sourceFile = PropertiesParser.builder().build().parse(source)
+          .filter(Properties.File.class::isInstance)
+          .map(Properties.File.class::cast)
+          .findFirst()
+          .orElseThrow();
+
+        assertThat(FindQuarkusProfiles.find(sourceFile))
+          .containsExactlyInAnyOrder("dev", "staging", "prod");
+    }
+
+    @Test
+    void yamlFile() {
+        @Language("yml")
+        String source = """
+          quarkus:
+            http:
+              port: 8080
+          "%dev":
+            quarkus:
+              http:
+                port: 9090
+          "%staging,prod":
+            quarkus:
+              http:
+                root-path: /quarkus
+          """;
+
+        Yaml.Documents sourceFile = YamlParser.builder().build().parse(source)
+          .filter(Yaml.Documents.class::isInstance)
+          .map(Yaml.Documents.class::cast)
+          .findFirst()
+          .orElseThrow();
+
+        assertThat(FindQuarkusProfiles.find(sourceFile))
+          .containsExactlyInAnyOrder("dev", "staging", "prod");
+    }
+}

--- a/src/test/java/org/openrewrite/quarkus/search/FindQuarkusProfilesTest.java
+++ b/src/test/java/org/openrewrite/quarkus/search/FindQuarkusProfilesTest.java
@@ -17,7 +17,6 @@ package org.openrewrite.quarkus.search;
 
 import org.intellij.lang.annotations.Language;
 import org.junit.jupiter.api.Test;
-import org.openrewrite.InMemoryExecutionContext;
 import org.openrewrite.properties.PropertiesParser;
 import org.openrewrite.properties.tree.Properties;
 import org.openrewrite.test.RecipeSpec;
@@ -31,7 +30,7 @@ class FindQuarkusProfilesTest implements RewriteTest {
 
     @Override
     public void defaults(RecipeSpec spec) {
-        spec.recipe(new FindQuarkusProfiles()).executionContext(new InMemoryExecutionContext());
+        spec.recipe(new FindQuarkusProfiles());
     }
 
     @Test

--- a/src/test/java/org/openrewrite/quarkus/search/FindQuarkusPropertiesTest.java
+++ b/src/test/java/org/openrewrite/quarkus/search/FindQuarkusPropertiesTest.java
@@ -59,7 +59,7 @@ class FindQuarkusPropertiesTest {
             rewriteRun(
               spec -> spec.recipe(new FindQuarkusProperties("quarkus.http.port", null, null)),
               //language=properties
-              properties(sourceProperties)
+              properties(sourceProperties, spec -> spec.path("src/main/resources/application.properties"))
             );
         }
 
@@ -76,7 +76,7 @@ class FindQuarkusPropertiesTest {
                 quarkus.hibernate-search-orm."unitname".automatic-indexing.synchronization.strategy=~~>test
                 %dev.quarkus.hibernate-search-orm."unitname".automatic-indexing.synchronization.strategy=test
                 %staging,prod.quarkus.hibernate-search-orm."unitname".automatic-indexing.synchronization.strategy=test
-                """)
+                """, spec -> spec.path("src/main/resources/application.properties"))
             );
         }
 
@@ -93,7 +93,7 @@ class FindQuarkusPropertiesTest {
                 quarkus.hibernate-search-orm."unitname".automatic-indexing.synchronization.strategy=~~>test
                 %dev.quarkus.hibernate-search-orm."unitname".automatic-indexing.synchronization.strategy=~~>test
                 %staging,prod.quarkus.hibernate-search-orm."unitname".automatic-indexing.synchronization.strategy=~~>test
-                """)
+                """, spec -> spec.path("src/main/resources/application.properties"))
             );
         }
 
@@ -110,7 +110,7 @@ class FindQuarkusPropertiesTest {
                 quarkus.hibernate-search-orm."unitname".automatic-indexing.synchronization.strategy=test
                 %dev.quarkus.hibernate-search-orm."unitname".automatic-indexing.synchronization.strategy=test
                 %staging,prod.quarkus.hibernate-search-orm."unitname".automatic-indexing.synchronization.strategy=~~>test
-                """)
+                """, spec -> spec.path("src/main/resources/application.properties"))
             );
         }
     }
@@ -156,7 +156,7 @@ class FindQuarkusPropertiesTest {
             rewriteRun(
               spec -> spec.recipe(new FindQuarkusProperties("quarkus.http.port", null, null)),
               //language=yaml
-              yaml(sourceYaml)
+              yaml(sourceYaml, spec -> spec.path("src/main/resources/application.yaml"))
             );
         }
 
@@ -195,7 +195,7 @@ class FindQuarkusPropertiesTest {
                         automatic-indexing:
                           synchronization:
                             strategy: test
-                """)
+                """, spec -> spec.path("src/main/resources/application.yaml"))
             );
         }
 
@@ -234,7 +234,7 @@ class FindQuarkusPropertiesTest {
                         automatic-indexing:
                           synchronization:
                             strategy: ~~>test
-                """)
+                """, spec -> spec.path("src/main/resources/application.yaml"))
             );
         }
 
@@ -273,7 +273,7 @@ class FindQuarkusPropertiesTest {
                         automatic-indexing:
                           synchronization:
                             strategy: ~~>test
-                """)
+                """, spec -> spec.path("src/main/resources/application.yaml"))
             );
         }
     }

--- a/src/test/java/org/openrewrite/quarkus/search/FindQuarkusPropertiesTest.java
+++ b/src/test/java/org/openrewrite/quarkus/search/FindQuarkusPropertiesTest.java
@@ -66,7 +66,7 @@ class FindQuarkusPropertiesTest {
         @Test
         void existingPropertyNoProfile() {
             rewriteRun(
-              spec -> spec.recipe(new FindQuarkusProperties(propertyKey, null, null)),
+              spec -> spec.recipe(new FindQuarkusProperties(propertyKey, null, false)),
               //language=properties
               properties(sourceProperties, """
                 ~~>quarkus.hibernate-search-orm.automatic-indexing.synchronization.strategy=test
@@ -163,7 +163,7 @@ class FindQuarkusPropertiesTest {
         @Test
         void existingPropertyNoProfile() {
             rewriteRun(
-              spec -> spec.recipe(new FindQuarkusProperties(propertyKey, null, null)),
+              spec -> spec.recipe(new FindQuarkusProperties(propertyKey, null, false)),
               //language=yaml
               yaml(sourceYaml, """
                 '%dev':

--- a/src/test/java/org/openrewrite/quarkus/search/FindQuarkusPropertiesTest.java
+++ b/src/test/java/org/openrewrite/quarkus/search/FindQuarkusPropertiesTest.java
@@ -69,11 +69,11 @@ class FindQuarkusPropertiesTest {
               spec -> spec.recipe(new FindQuarkusProperties(propertyKey, null, null)),
               //language=properties
               properties(sourceProperties, """
-                quarkus.hibernate-search-orm.automatic-indexing.synchronization.strategy=~~>test
+                ~~>quarkus.hibernate-search-orm.automatic-indexing.synchronization.strategy=test
                 %dev.quarkus.hibernate-search-orm.automatic-indexing.synchronization.strategy=test
                 %staging,prod.quarkus.hibernate-search-orm.automatic-indexing.synchronization.strategy=test
-                      
-                quarkus.hibernate-search-orm."unitname".automatic-indexing.synchronization.strategy=~~>test
+                
+                ~~>quarkus.hibernate-search-orm."unitname".automatic-indexing.synchronization.strategy=test
                 %dev.quarkus.hibernate-search-orm."unitname".automatic-indexing.synchronization.strategy=test
                 %staging,prod.quarkus.hibernate-search-orm."unitname".automatic-indexing.synchronization.strategy=test
                 """, spec -> spec.path("src/main/resources/application.properties"))
@@ -86,13 +86,13 @@ class FindQuarkusPropertiesTest {
               spec -> spec.recipe(new FindQuarkusProperties(propertyKey, null, true)),
               //language=properties
               properties(sourceProperties, """
-                quarkus.hibernate-search-orm.automatic-indexing.synchronization.strategy=~~>test
-                %dev.quarkus.hibernate-search-orm.automatic-indexing.synchronization.strategy=~~>test
-                %staging,prod.quarkus.hibernate-search-orm.automatic-indexing.synchronization.strategy=~~>test
-                      
-                quarkus.hibernate-search-orm."unitname".automatic-indexing.synchronization.strategy=~~>test
-                %dev.quarkus.hibernate-search-orm."unitname".automatic-indexing.synchronization.strategy=~~>test
-                %staging,prod.quarkus.hibernate-search-orm."unitname".automatic-indexing.synchronization.strategy=~~>test
+                ~~>quarkus.hibernate-search-orm.automatic-indexing.synchronization.strategy=test
+                ~~>%dev.quarkus.hibernate-search-orm.automatic-indexing.synchronization.strategy=test
+                ~~>%staging,prod.quarkus.hibernate-search-orm.automatic-indexing.synchronization.strategy=test
+                
+                ~~>quarkus.hibernate-search-orm."unitname".automatic-indexing.synchronization.strategy=test
+                ~~>%dev.quarkus.hibernate-search-orm."unitname".automatic-indexing.synchronization.strategy=test
+                ~~>%staging,prod.quarkus.hibernate-search-orm."unitname".automatic-indexing.synchronization.strategy=test
                 """, spec -> spec.path("src/main/resources/application.properties"))
             );
         }
@@ -105,11 +105,11 @@ class FindQuarkusPropertiesTest {
               properties(sourceProperties, """
                 quarkus.hibernate-search-orm.automatic-indexing.synchronization.strategy=test
                 %dev.quarkus.hibernate-search-orm.automatic-indexing.synchronization.strategy=test
-                %staging,prod.quarkus.hibernate-search-orm.automatic-indexing.synchronization.strategy=~~>test
-                      
+                ~~>%staging,prod.quarkus.hibernate-search-orm.automatic-indexing.synchronization.strategy=test
+                
                 quarkus.hibernate-search-orm."unitname".automatic-indexing.synchronization.strategy=test
                 %dev.quarkus.hibernate-search-orm."unitname".automatic-indexing.synchronization.strategy=test
-                %staging,prod.quarkus.hibernate-search-orm."unitname".automatic-indexing.synchronization.strategy=~~>test
+                ~~>%staging,prod.quarkus.hibernate-search-orm."unitname".automatic-indexing.synchronization.strategy=test
                 """, spec -> spec.path("src/main/resources/application.properties"))
             );
         }
@@ -180,11 +180,11 @@ class FindQuarkusPropertiesTest {
                   hibernate-search-orm:
                     automatic-indexing:
                       synchronization:
-                        strategy: ~~>test
+                        ~~>strategy: test
                     unitname:
                       automatic-indexing:
                         synchronization:
-                          strategy: ~~>test
+                          ~~>strategy: test
                 '%staging,prod':
                   quarkus:
                     hibernate-search-orm:
@@ -210,30 +210,30 @@ class FindQuarkusPropertiesTest {
                     hibernate-search-orm:
                       automatic-indexing:
                         synchronization:
-                          strategy: ~~>test
+                          ~~>strategy: test
                       unitname:
                         automatic-indexing:
                           synchronization:
-                            strategy: ~~>test
+                            ~~>strategy: test
                 quarkus:
                   hibernate-search-orm:
                     automatic-indexing:
                       synchronization:
-                        strategy: ~~>test
+                        ~~>strategy: test
                     unitname:
                       automatic-indexing:
                         synchronization:
-                          strategy: ~~>test
+                          ~~>strategy: test
                 '%staging,prod':
                   quarkus:
                     hibernate-search-orm:
                       automatic-indexing:
                         synchronization:
-                          strategy: ~~>test
+                          ~~>strategy: test
                       unitname:
                         automatic-indexing:
                           synchronization:
-                            strategy: ~~>test
+                            ~~>strategy: test
                 """, spec -> spec.path("src/main/resources/application.yaml"))
             );
         }
@@ -268,11 +268,11 @@ class FindQuarkusPropertiesTest {
                     hibernate-search-orm:
                       automatic-indexing:
                         synchronization:
-                          strategy: ~~>test
+                          ~~>strategy: test
                       unitname:
                         automatic-indexing:
                           synchronization:
-                            strategy: ~~>test
+                            ~~>strategy: test
                 """, spec -> spec.path("src/main/resources/application.yaml"))
             );
         }

--- a/src/test/java/org/openrewrite/quarkus/search/FindQuarkusPropertiesTest.java
+++ b/src/test/java/org/openrewrite/quarkus/search/FindQuarkusPropertiesTest.java
@@ -1,0 +1,280 @@
+/*
+ * Copyright 2023 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.quarkus.search;
+
+import org.intellij.lang.annotations.Language;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.openrewrite.test.RewriteTest;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.openrewrite.properties.Assertions.properties;
+import static org.openrewrite.yaml.Assertions.yaml;
+
+class FindQuarkusPropertiesTest {
+
+    private final String propertyKey = "quarkus.hibernate-search-orm(?:\\..*?)?.automatic-indexing.synchronization.strategy";
+
+    @Test
+    void validationOptions() {
+        FindQuarkusProperties recipe = new FindQuarkusProperties("quarkus.http.port", null, null);
+        assertThat(recipe.validate().isValid()).isTrue();
+
+        recipe = new FindQuarkusProperties("quarkus.http.port", "dev", null);
+        assertThat(recipe.validate().isValid()).isTrue();
+
+        recipe = new FindQuarkusProperties("quarkus.http.port", "dev", true);
+        assertThat(recipe.validate().isValid()).isFalse();
+    }
+
+    @Nested
+    class Properties implements RewriteTest {
+
+        @Language("properties")
+        private final String sourceProperties = """
+          quarkus.hibernate-search-orm.automatic-indexing.synchronization.strategy=test
+          %dev.quarkus.hibernate-search-orm.automatic-indexing.synchronization.strategy=test
+          %staging,prod.quarkus.hibernate-search-orm.automatic-indexing.synchronization.strategy=test
+                
+          quarkus.hibernate-search-orm."unitname".automatic-indexing.synchronization.strategy=test
+          %dev.quarkus.hibernate-search-orm."unitname".automatic-indexing.synchronization.strategy=test
+          %staging,prod.quarkus.hibernate-search-orm."unitname".automatic-indexing.synchronization.strategy=test
+          """;
+
+        @Test
+        void nonExistingProperty() {
+            rewriteRun(
+              spec -> spec.recipe(new FindQuarkusProperties("quarkus.http.port", null, null)),
+              //language=properties
+              properties(sourceProperties)
+            );
+        }
+
+        @Test
+        void existingPropertyNoProfile() {
+            rewriteRun(
+              spec -> spec.recipe(new FindQuarkusProperties(propertyKey, null, null)),
+              //language=properties
+              properties(sourceProperties, """
+                quarkus.hibernate-search-orm.automatic-indexing.synchronization.strategy=~~>test
+                %dev.quarkus.hibernate-search-orm.automatic-indexing.synchronization.strategy=test
+                %staging,prod.quarkus.hibernate-search-orm.automatic-indexing.synchronization.strategy=test
+                      
+                quarkus.hibernate-search-orm."unitname".automatic-indexing.synchronization.strategy=~~>test
+                %dev.quarkus.hibernate-search-orm."unitname".automatic-indexing.synchronization.strategy=test
+                %staging,prod.quarkus.hibernate-search-orm."unitname".automatic-indexing.synchronization.strategy=test
+                """)
+            );
+        }
+
+        @Test
+        void existingPropertyAllProfiles() {
+            rewriteRun(
+              spec -> spec.recipe(new FindQuarkusProperties(propertyKey, null, true)),
+              //language=properties
+              properties(sourceProperties, """
+                quarkus.hibernate-search-orm.automatic-indexing.synchronization.strategy=~~>test
+                %dev.quarkus.hibernate-search-orm.automatic-indexing.synchronization.strategy=~~>test
+                %staging,prod.quarkus.hibernate-search-orm.automatic-indexing.synchronization.strategy=~~>test
+                      
+                quarkus.hibernate-search-orm."unitname".automatic-indexing.synchronization.strategy=~~>test
+                %dev.quarkus.hibernate-search-orm."unitname".automatic-indexing.synchronization.strategy=~~>test
+                %staging,prod.quarkus.hibernate-search-orm."unitname".automatic-indexing.synchronization.strategy=~~>test
+                """)
+            );
+        }
+
+        @Test
+        void existingPropertyNamedProfile() {
+            rewriteRun(
+              spec -> spec.recipe(new FindQuarkusProperties(propertyKey, "staging", false)),
+              //language=properties
+              properties(sourceProperties, """
+                quarkus.hibernate-search-orm.automatic-indexing.synchronization.strategy=test
+                %dev.quarkus.hibernate-search-orm.automatic-indexing.synchronization.strategy=test
+                %staging,prod.quarkus.hibernate-search-orm.automatic-indexing.synchronization.strategy=~~>test
+                      
+                quarkus.hibernate-search-orm."unitname".automatic-indexing.synchronization.strategy=test
+                %dev.quarkus.hibernate-search-orm."unitname".automatic-indexing.synchronization.strategy=test
+                %staging,prod.quarkus.hibernate-search-orm."unitname".automatic-indexing.synchronization.strategy=~~>test
+                """)
+            );
+        }
+    }
+
+    @Nested
+    class Yaml implements RewriteTest {
+
+        @Language("yml")
+        private final String sourceYaml = """
+          '%dev':
+            quarkus:
+              hibernate-search-orm:
+                automatic-indexing:
+                  synchronization:
+                    strategy: test
+                unitname:
+                  automatic-indexing:
+                    synchronization:
+                      strategy: test
+          quarkus:
+            hibernate-search-orm:
+              automatic-indexing:
+                synchronization:
+                  strategy: test
+              unitname:
+                automatic-indexing:
+                  synchronization:
+                    strategy: test
+          '%staging,prod':
+            quarkus:
+              hibernate-search-orm:
+                automatic-indexing:
+                  synchronization:
+                    strategy: test
+                unitname:
+                  automatic-indexing:
+                    synchronization:
+                      strategy: test
+          """;
+
+        @Test
+        void nonExistingProperty() {
+            rewriteRun(
+              spec -> spec.recipe(new FindQuarkusProperties("quarkus.http.port", null, null)),
+              //language=yaml
+              yaml(sourceYaml)
+            );
+        }
+
+        @Test
+        void existingPropertyNoProfile() {
+            rewriteRun(
+              spec -> spec.recipe(new FindQuarkusProperties(propertyKey, null, null)),
+              //language=yaml
+              yaml(sourceYaml, """
+                '%dev':
+                  quarkus:
+                    hibernate-search-orm:
+                      automatic-indexing:
+                        synchronization:
+                          strategy: test
+                      unitname:
+                        automatic-indexing:
+                          synchronization:
+                            strategy: test
+                quarkus:
+                  hibernate-search-orm:
+                    automatic-indexing:
+                      synchronization:
+                        strategy: ~~>test
+                    unitname:
+                      automatic-indexing:
+                        synchronization:
+                          strategy: ~~>test
+                '%staging,prod':
+                  quarkus:
+                    hibernate-search-orm:
+                      automatic-indexing:
+                        synchronization:
+                          strategy: test
+                      unitname:
+                        automatic-indexing:
+                          synchronization:
+                            strategy: test
+                """)
+            );
+        }
+
+        @Test
+        void existingPropertyAllProfiles() {
+            rewriteRun(
+              spec -> spec.recipe(new FindQuarkusProperties(propertyKey, null, true)),
+              //language=yaml
+              yaml(sourceYaml, """
+                '%dev':
+                  quarkus:
+                    hibernate-search-orm:
+                      automatic-indexing:
+                        synchronization:
+                          strategy: ~~>test
+                      unitname:
+                        automatic-indexing:
+                          synchronization:
+                            strategy: ~~>test
+                quarkus:
+                  hibernate-search-orm:
+                    automatic-indexing:
+                      synchronization:
+                        strategy: ~~>test
+                    unitname:
+                      automatic-indexing:
+                        synchronization:
+                          strategy: ~~>test
+                '%staging,prod':
+                  quarkus:
+                    hibernate-search-orm:
+                      automatic-indexing:
+                        synchronization:
+                          strategy: ~~>test
+                      unitname:
+                        automatic-indexing:
+                          synchronization:
+                            strategy: ~~>test
+                """)
+            );
+        }
+
+        @Test
+        void existingPropertyNamedProfile() {
+            rewriteRun(
+              spec -> spec.recipe(new FindQuarkusProperties(propertyKey, "staging", false)),
+              //language=yaml
+              yaml(sourceYaml, """
+                '%dev':
+                  quarkus:
+                    hibernate-search-orm:
+                      automatic-indexing:
+                        synchronization:
+                          strategy: test
+                      unitname:
+                        automatic-indexing:
+                          synchronization:
+                            strategy: test
+                quarkus:
+                  hibernate-search-orm:
+                    automatic-indexing:
+                      synchronization:
+                        strategy: test
+                    unitname:
+                      automatic-indexing:
+                        synchronization:
+                          strategy: test
+                '%staging,prod':
+                  quarkus:
+                    hibernate-search-orm:
+                      automatic-indexing:
+                        synchronization:
+                          strategy: ~~>test
+                      unitname:
+                        automatic-indexing:
+                          synchronization:
+                            strategy: ~~>test
+                """)
+            );
+        }
+    }
+}


### PR DESCRIPTION
## What's changed?
<!-- A brief description of the changes in this pull request -->
Add recipes to find properties and profiles in use, and to change property keys.

## What's your motivation?
<!-- This can link to close a separate issue, or be described on the pull request itself -->
Adding recipes to resolve #69.

## Anything in particular you'd like reviewers to focus on?
<!-- You can also start a discussion on particular aspects of your implementation on the files tab yourself. -->

## Anyone you would like to review specifically?
<!-- @mention them here -->
@gsmet @timtebeek 

## Have you considered any alternatives or workarounds?
<!-- Any other ways to solve the problem, or ways to work around the problem. -->
~~No workarounds for dealing with Quarkus profiles. Specs for microprofile config shows only a single profile per property, but @gsmet's example has two. Is it allowed?~~
No

## Any additional context
<!-- Any thoughts you would like to share in addition to the above. -->
I've used regular expression to solve the "unitname" problem on Quarkus properties, but the project preference seems to be glob expressions. 

### Checklist
- [x] I've added unit tests to cover both positive and negative cases
- [x] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [x] I've used the IntelliJ IDEA auto-formatter on affected files
