### PR TITLE
Remove quarkus-update-recipes again to allow reuse

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -27,9 +27,6 @@ dependencies {
 
     implementation("org.openrewrite.recipe:rewrite-java-dependencies:${rewriteVersion}")
 
-    implementation("io.quarkus:quarkus-update-recipes:latest.release")
-    implementation("io.quarkus:quarkus-update-recipes:latest.release:core")
-
     runtimeOnly("org.openrewrite:rewrite-java-17:${rewriteVersion}")
 
     testImplementation("org.openrewrite:rewrite-test:${rewriteVersion}")

--- a/src/main/resources/META-INF/rewrite/category.yml
+++ b/src/main/resources/META-INF/rewrite/category.yml
@@ -22,7 +22,3 @@ description: Recipes for upgrading and patching [Quarkus](https://quarkus.io/) a
 type: specs.openrewrite.org/v1beta/category
 name: Quarkus 2.x
 packageName: org.openrewrite.quarkus.quarkus2
----
-type: specs.openrewrite.org/v1beta/category
-name: Quarkus 3.x
-packageName: io.quarkus


### PR DESCRIPTION
We don't want any circular dependencies, so if `quarkus-update-recipes` wants to depend on `rewrite-quarkus` it's best to remove the dependency here.