### PR TITLE
Expect new property prefix insertion order in tests

### DIFF
--- a/src/test/java/org/openrewrite/quarkus/AddQuarkusPropertyTest.java
+++ b/src/test/java/org/openrewrite/quarkus/AddQuarkusPropertyTest.java
@@ -35,8 +35,8 @@ class AddQuarkusPropertyTest implements RewriteTest {
               quarkus.http.root-path=/api
               """,
             """
-              quarkus.http.root-path=/api
               quarkus.http.port=9090
+              quarkus.http.root-path=/api
               """,
             spec -> spec.path("src/main/resources/application.properties")
           ),
@@ -68,8 +68,8 @@ class AddQuarkusPropertyTest implements RewriteTest {
               quarkus.http.port=9090
               """,
             """
-              quarkus.http.port=9090
               fred=fred
+              quarkus.http.port=9090
               """,
             spec -> spec.path("src/main/resources/application.properties")
           ),
@@ -99,9 +99,11 @@ class AddQuarkusPropertyTest implements RewriteTest {
           properties(
             """
               quarkus.http.port=9090
+              %dev.foo=bar
               """,
             """
               quarkus.http.port=9090
+              %dev.foo=bar
               %dev.fred=fred
               """,
             spec -> spec.path("src/main/resources/application.properties")

--- a/src/test/java/org/openrewrite/quarkus/ChangeQuarkusPropertyKeyTest.java
+++ b/src/test/java/org/openrewrite/quarkus/ChangeQuarkusPropertyKeyTest.java
@@ -77,13 +77,13 @@ class ChangeQuarkusPropertyKeyTest {
             String after = """
               quarkus.hibernate-search-orm.automatic-indexing.synchronization.strategy=read-sync
               %dev.quarkus.hibernate-search-orm.automatic-indexing.synchronization.strategy=sync
-                            
+              %prod.quarkus.hibernate-search-orm."unitname".indexing.plan.synchronization.strategy=async
+              %prod.quarkus.hibernate-search-orm.indexing.plan.synchronization.strategy=async
+              %staging.quarkus.hibernate-search-orm."unitname".automatic-indexing.synchronization.strategy=async
+              %staging.quarkus.hibernate-search-orm.automatic-indexing.synchronization.strategy=async
+              
               quarkus.hibernate-search-orm."unitname".automatic-indexing.synchronization.strategy=read-sync
               %dev.quarkus.hibernate-search-orm."unitname".automatic-indexing.synchronization.strategy=sync
-              %prod.quarkus.hibernate-search-orm."unitname".indexing.plan.synchronization.strategy=async
-              %staging.quarkus.hibernate-search-orm."unitname".automatic-indexing.synchronization.strategy=async
-              %prod.quarkus.hibernate-search-orm.indexing.plan.synchronization.strategy=async
-              %staging.quarkus.hibernate-search-orm.automatic-indexing.synchronization.strategy=async
               """;
 
             rewriteRun(

--- a/src/test/java/org/openrewrite/quarkus/ChangeQuarkusPropertyValueTest.java
+++ b/src/test/java/org/openrewrite/quarkus/ChangeQuarkusPropertyValueTest.java
@@ -77,13 +77,13 @@ class ChangeQuarkusPropertyValueTest implements RewriteTest {
             String after = """
               quarkus.hibernate-search-orm.automatic-indexing.synchronization.strategy=read-sync
               %dev.quarkus.hibernate-search-orm.automatic-indexing.synchronization.strategy=sync
-                            
-              quarkus.hibernate-search-orm."unitname".automatic-indexing.synchronization.strategy=read-sync
-              %dev.quarkus.hibernate-search-orm."unitname".automatic-indexing.synchronization.strategy=sync
               %prod.quarkus.hibernate-search-orm."unitname".automatic-indexing.synchronization.strategy=async
               %prod.quarkus.hibernate-search-orm.automatic-indexing.synchronization.strategy=async
               %staging.quarkus.hibernate-search-orm."unitname".automatic-indexing.synchronization.strategy=write-sync
               %staging.quarkus.hibernate-search-orm.automatic-indexing.synchronization.strategy=write-sync
+                            
+              quarkus.hibernate-search-orm."unitname".automatic-indexing.synchronization.strategy=read-sync
+              %dev.quarkus.hibernate-search-orm."unitname".automatic-indexing.synchronization.strategy=sync
               """;
 
             rewriteRun(

--- a/src/test/java/org/openrewrite/quarkus/DeleteQuarkusPropertyTest.java
+++ b/src/test/java/org/openrewrite/quarkus/DeleteQuarkusPropertyTest.java
@@ -76,11 +76,11 @@ class DeleteQuarkusPropertyTest implements RewriteTest {
             String after = """
               quarkus.hibernate-search-orm.automatic-indexing.synchronization.strategy=read-sync
               %dev.quarkus.hibernate-search-orm.automatic-indexing.synchronization.strategy=sync
-                        
-              quarkus.hibernate-search-orm."unitname".automatic-indexing.synchronization.strategy=read-sync
-              %dev.quarkus.hibernate-search-orm."unitname".automatic-indexing.synchronization.strategy=sync
               %prod.quarkus.hibernate-search-orm."unitname".automatic-indexing.synchronization.strategy=async
               %prod.quarkus.hibernate-search-orm.automatic-indexing.synchronization.strategy=async
+              
+              quarkus.hibernate-search-orm."unitname".automatic-indexing.synchronization.strategy=read-sync
+              %dev.quarkus.hibernate-search-orm."unitname".automatic-indexing.synchronization.strategy=sync
               """;
 
             rewriteRun(


### PR DESCRIPTION
## What's changed?
Update tests to expect the new property insertion order introduced in  https://github.com/openrewrite/rewrite/commits/main/rewrite-properties/src/main/java/org/openrewrite/properties
The exact insertion point depends on properties already present, which is tested in openrewrite/rewrite extensively and should work better in practice versus what the tests indicate in the minimal examples here.

## What's your motivation?
Fix tests to get build going again.