### PR TITLE
Quarkus Add/Change/Delete property recipe to use the custom pathExpression

### DIFF
--- a/src/main/java/org/openrewrite/quarkus/AddQuarkusProperty.java
+++ b/src/main/java/org/openrewrite/quarkus/AddQuarkusProperty.java
@@ -91,7 +91,7 @@ public class AddQuarkusProperty extends Recipe {
             @Override
             public boolean isAcceptable(SourceFile sourceFile, ExecutionContext ctx) {
                 QuarkusExecutionContextView quarkusCtx = QuarkusExecutionContextView.view(ctx);
-                return quarkusCtx.isQuarkusConfigFile(sourceFile, null);
+                return quarkusCtx.isQuarkusConfigFile(sourceFile, pathExpressions);
             }
 
             @Override

--- a/src/main/java/org/openrewrite/quarkus/ChangeQuarkusPropertyKey.java
+++ b/src/main/java/org/openrewrite/quarkus/ChangeQuarkusPropertyKey.java
@@ -90,7 +90,7 @@ public class ChangeQuarkusPropertyKey extends Recipe {
     @Override
     public TreeVisitor<?, ExecutionContext> getVisitor() {
         return Preconditions.check(
-                new FindQuarkusProperties(oldPropertyKey, profile, changeAllProfiles).getVisitor(),
+                new FindQuarkusProperties(oldPropertyKey, profile, changeAllProfiles, pathExpressions).getVisitor(),
                 new ChangeQuarkusPropertyKeyVisitor(oldPropertyKey, newPropertyKey, profile, changeAllProfiles, pathExpressions)
         );
     }

--- a/src/main/java/org/openrewrite/quarkus/ChangeQuarkusPropertyValue.java
+++ b/src/main/java/org/openrewrite/quarkus/ChangeQuarkusPropertyValue.java
@@ -96,7 +96,7 @@ public class ChangeQuarkusPropertyValue extends Recipe {
     @Override
     public TreeVisitor<?, ExecutionContext> getVisitor() {
         return Preconditions.check(
-                new FindQuarkusProperties(propertyKey, profile, changeAllProfiles).getVisitor(),
+                new FindQuarkusProperties(propertyKey, profile, changeAllProfiles, pathExpressions).getVisitor(),
                 new ChangeQuarkusPropertyValueVisitor(propertyKey, newValue, oldValue, profile, changeAllProfiles, pathExpressions)
         );
     }

--- a/src/main/java/org/openrewrite/quarkus/DeleteQuarkusProperty.java
+++ b/src/main/java/org/openrewrite/quarkus/DeleteQuarkusProperty.java
@@ -91,7 +91,7 @@ public class DeleteQuarkusProperty extends Recipe {
     @Override
     public TreeVisitor<?, ExecutionContext> getVisitor() {
         return Preconditions.check(
-                new FindQuarkusProperties(propertyKey, profile, deleteFromAllProfiles).getVisitor(),
+                new FindQuarkusProperties(propertyKey, profile, deleteFromAllProfiles, pathExpressions).getVisitor(),
                 new DeleteQuarkusPropertyVisitor(propertyKey, oldValue, profile, deleteFromAllProfiles, pathExpressions)
         );
     }

--- a/src/main/java/org/openrewrite/quarkus/search/FindQuarkusProperties.java
+++ b/src/main/java/org/openrewrite/quarkus/search/FindQuarkusProperties.java
@@ -29,10 +29,7 @@ import org.openrewrite.yaml.YamlIsoVisitor;
 import org.openrewrite.yaml.tree.Yaml;
 import org.openrewrite.yaml.tree.YamlKey;
 
-import java.util.Comparator;
-import java.util.Iterator;
-import java.util.Set;
-import java.util.TreeSet;
+import java.util.*;
 import java.util.regex.Pattern;
 
 @Value
@@ -67,6 +64,16 @@ public class FindQuarkusProperties extends Recipe {
             example = "false")
     @Nullable
     Boolean searchAllProfiles;
+
+    @Option(displayName = "Optional list of file path matcher",
+            description = "Each value in this list represents a glob expression that is used to match which files will " +
+                    "be modified. If this value is not present, this recipe will query the execution context for " +
+                    "reasonable defaults. (\"**/application.yml\", \"**/application.yaml\", " +
+                    "\"**/application.properties\" and \"**/META-INF/microprofile-config.properties\".",
+            required = false,
+            example = "[\"**/application.yaml\"]")
+    @Nullable
+    List<String> pathExpressions;
 
     @Override
     public Validated<Object> validate() {
@@ -153,7 +160,7 @@ public class FindQuarkusProperties extends Recipe {
             @Override
             public boolean isAcceptable(SourceFile sourceFile, ExecutionContext ctx) {
                 QuarkusExecutionContextView quarkusCtx = QuarkusExecutionContextView.view(ctx);
-                return quarkusCtx.isQuarkusConfigFile(sourceFile, null);
+                return quarkusCtx.isQuarkusConfigFile(sourceFile, pathExpressions);
             }
 
             @Override

--- a/src/test/java/org/openrewrite/quarkus/AddQuarkusPropertyTest.java
+++ b/src/test/java/org/openrewrite/quarkus/AddQuarkusPropertyTest.java
@@ -19,6 +19,8 @@ import org.junit.jupiter.api.Test;
 import org.openrewrite.DocumentExample;
 import org.openrewrite.test.RewriteTest;
 
+import java.util.List;
+
 import static org.openrewrite.properties.Assertions.properties;
 import static org.openrewrite.yaml.Assertions.yaml;
 
@@ -242,6 +244,42 @@ class AddQuarkusPropertyTest implements RewriteTest {
                   port: 9090
               """,
             s -> s.path("src/main/resources/application-dev.yml")
+          )
+        );
+    }
+
+    @Test
+    void makeChangeToMatchingFilesWithCustomPathExpression() {
+        rewriteRun(
+          spec -> spec.recipe(new AddQuarkusProperty("quarkus.http.root-path", "/api", "This property was added", null, List.of("**/custom.{properties,yaml,yml}"))),
+          properties("# Sample empty properties file", s -> s.path("src/main/resources/test.properties")),
+          //language=properties
+          properties(
+            """
+              quarkus.http.port=9090
+              """,
+            """
+              quarkus.http.port=9090
+              # This property was added
+              quarkus.http.root-path=/api
+              """,
+            s -> s.path("src/main/resources/custom.properties")
+          ),
+          //language=yaml
+          yaml(
+            """
+              quarkus:
+                http:
+                  port: 9090
+              """,
+            """
+              quarkus:
+                http:
+                  port: 9090
+                  # This property was added
+                  root-path: /api
+              """,
+            s -> s.path("src/main/resources/custom.yml")
           )
         );
     }

--- a/src/test/java/org/openrewrite/quarkus/DeleteQuarkusPropertyTest.java
+++ b/src/test/java/org/openrewrite/quarkus/DeleteQuarkusPropertyTest.java
@@ -20,6 +20,8 @@ import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.openrewrite.test.RewriteTest;
 
+import java.util.List;
+
 import static org.openrewrite.properties.Assertions.properties;
 import static org.openrewrite.yaml.Assertions.yaml;
 
@@ -108,6 +110,16 @@ class DeleteQuarkusPropertyTest implements RewriteTest {
                 "quarkus\\.hibernate-search-orm(\\..*)?\\.automatic-indexing\\.synchronization\\.strategy",
                 null, null, null, null)),
               properties(sourceProperties, "", spec -> spec.path("src/main/resources/application.properties"))
+            );
+        }
+
+        @Test
+        void deleteValueOnCustomPath() {
+            rewriteRun(
+              spec -> spec.recipe(new DeleteQuarkusProperty(
+                "quarkus\\.hibernate-search-orm(\\..*)?\\.automatic-indexing\\.synchronization\\.strategy",
+                null, null, true, List.of("**/custom.{properties,yaml,yml}"))),
+              properties(sourceProperties, "", spec -> spec.path("src/main/resources/custom.properties"))
             );
         }
     }
@@ -254,6 +266,16 @@ class DeleteQuarkusPropertyTest implements RewriteTest {
                 "quarkus\\.hibernate-search-orm(\\..*)?\\.automatic-indexing\\.synchronization\\.strategy",
                 null, null, true, null)),
               yaml(sourceYaml, "", spec -> spec.path("src/main/resources/application.yaml"))
+            );
+        }
+
+        @Test
+        void deleteValueOnCustomPath() {
+            rewriteRun(
+              spec -> spec.recipe(new DeleteQuarkusProperty(
+                "quarkus\\.hibernate-search-orm(\\..*)?\\.automatic-indexing\\.synchronization\\.strategy",
+                null, null, true, List.of("**/custom.{properties,yaml,yml}"))),
+              yaml(sourceYaml, "", spec -> spec.path("src/main/resources/custom.yaml"))
             );
         }
     }


### PR DESCRIPTION
## What's changed?
- Update FindQuarkusProperties to use the custom pathExpression to support dependent Add/Change?delete property recipes

## What's your motivation?
- Fixes https://github.com/openrewrite/rewrite-quarkus/issues/92

## Anyone you would like to review specifically?
@timtebeek 

## Any additional context
Post fix the recipe should be able to recognize property files other than default application.properties

### Checklist
- [x] I've added unit tests to cover both positive and negative cases
- [x] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [x] I've used the IntelliJ IDEA auto-formatter on affected files
