### PR TITLE
Drop `rewrite-migrate-java` dependency to limit ourselves to ASL

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -27,7 +27,6 @@ dependencies {
     implementation("org.openrewrite:rewrite-properties")
 
     implementation("org.openrewrite.recipe:rewrite-java-dependencies:${rewriteVersion}")
-    implementation("org.openrewrite.recipe:rewrite-migrate-java:${rewriteVersion}")
 
     runtimeOnly("org.openrewrite:rewrite-java-17")
 

--- a/src/main/resources/META-INF/rewrite/javaee7-to-quarkus.yml
+++ b/src/main/resources/META-INF/rewrite/javaee7-to-quarkus.yml
@@ -23,7 +23,6 @@ recipeList:
   - org.openrewrite.quarkus.migrate.javaee.RemoveJavaEEDependencies
 
   - org.openrewrite.quarkus.migrate.javaee.JavaEEtoQuarkus2CodeMigration
-  - org.openrewrite.java.migrate.Java8toJava11
 
 ---
 type: specs.openrewrite.org/v1beta/recipe

--- a/src/test/java/org/openrewrite/quarkus/migrate/javaee/JavaEEtoQuarkus2MavenDependenciesMigrationTest.java
+++ b/src/test/java/org/openrewrite/quarkus/migrate/javaee/JavaEEtoQuarkus2MavenDependenciesMigrationTest.java
@@ -232,14 +232,6 @@ class JavaEEtoQuarkus2MavenDependenciesMigrationTest implements RewriteTest {
                   <plugins>
                     <plugin>
                       <groupId>org.apache.maven.plugins</groupId>
-                      <artifactId>maven-compiler-plugin</artifactId>
-                      <configuration>
-                        <source>8</source>
-                        <target>8</target>
-                      </configuration>
-                    </plugin>
-                    <plugin>
-                      <groupId>org.apache.maven.plugins</groupId>
                       <artifactId>maven-war-plugin</artifactId>
                       <version>3.2.3</version>
                       <configuration>
@@ -264,12 +256,6 @@ class JavaEEtoQuarkus2MavenDependenciesMigrationTest implements RewriteTest {
                     <groupId>commons-beanutils</groupId>
                     <artifactId>commons-beanutils</artifactId>
                     <version>1.9.4</version>
-                  </dependency>
-                  <dependency>
-                    <groupId>org.projectlombok</groupId>
-                    <artifactId>lombok</artifactId>
-                    <version>1.18.30</version>
-                    <scope>provided</scope>
                   </dependency>
                   <dependency>
                     <groupId>com.fasterxml.jackson.jaxrs</groupId>
@@ -352,12 +338,6 @@ class JavaEEtoQuarkus2MavenDependenciesMigrationTest implements RewriteTest {
                     <artifactId>quarkus-undertow</artifactId>
                   </dependency>
                   <dependency>
-                    <groupId>org.projectlombok</groupId>
-                    <artifactId>lombok</artifactId>
-                    <version>1.18.36</version>
-                    <scope>provided</scope>
-                  </dependency>
-                  <dependency>
                     <groupId>io.quarkus</groupId>
                     <artifactId>quarkus-junit5</artifactId>
                     <scope>test</scope>
@@ -387,14 +367,6 @@ class JavaEEtoQuarkus2MavenDependenciesMigrationTest implements RewriteTest {
                 </dependencies>
                 <build>
                   <plugins>
-                    <plugin>
-                      <groupId>org.apache.maven.plugins</groupId>
-                      <artifactId>maven-compiler-plugin</artifactId>
-                      <version>3.13.0</version>
-                      <configuration>
-                        <release>11</release>
-                      </configuration>
-                    </plugin>
                     <plugin>
                       <groupId>io.quarkus.platform</groupId>
                       <artifactId>quarkus-maven-plugin</artifactId>

--- a/src/test/java/org/openrewrite/quarkus/migrate/javaee/JavaEEtoQuarkus2MavenDependenciesMigrationTest.java
+++ b/src/test/java/org/openrewrite/quarkus/migrate/javaee/JavaEEtoQuarkus2MavenDependenciesMigrationTest.java
@@ -305,6 +305,16 @@ class JavaEEtoQuarkus2MavenDependenciesMigrationTest implements RewriteTest {
 
                 <dependencies>
                   <dependency>
+                    <groupId>io.quarkus</groupId>
+                    <artifactId>quarkus-junit5</artifactId>
+                    <scope>test</scope>
+                  </dependency>
+                  <dependency>
+                    <groupId>io.rest-assured</groupId>
+                    <artifactId>rest-assured</artifactId>
+                    <scope>test</scope>
+                  </dependency>
+                  <dependency>
                     <groupId>org.apache.commons</groupId>
                     <artifactId>commons-lang3</artifactId>
                   </dependency>
@@ -336,16 +346,6 @@ class JavaEEtoQuarkus2MavenDependenciesMigrationTest implements RewriteTest {
                   <dependency>
                     <groupId>io.quarkus</groupId>
                     <artifactId>quarkus-undertow</artifactId>
-                  </dependency>
-                  <dependency>
-                    <groupId>io.quarkus</groupId>
-                    <artifactId>quarkus-junit5</artifactId>
-                    <scope>test</scope>
-                  </dependency>
-                  <dependency>
-                    <groupId>io.rest-assured</groupId>
-                    <artifactId>rest-assured</artifactId>
-                    <scope>test</scope>
                   </dependency>
                   <dependency>
                     <groupId>com.fasterxml.jackson.jaxrs</groupId>
@@ -380,6 +380,16 @@ class JavaEEtoQuarkus2MavenDependenciesMigrationTest implements RewriteTest {
                           </goals>
                         </execution>
                       </executions>
+                    </plugin>
+                    <plugin>
+                      <groupId>org.apache.maven.plugins</groupId>
+                      <artifactId>maven-compiler-plugin</artifactId>
+                      <version>3.13.0</version>
+                      <configuration>
+                        <compilerArgs>
+                          <arg>-parameters</arg>
+                        </compilerArgs>
+                      </configuration>
                     </plugin>
                     <plugin>
                       <groupId>org.apache.maven.plugins</groupId>


### PR DESCRIPTION
## What's your motivation?
- https://github.com/quarkusio/quarkus-updates/pull/242