### PR TITLE
New Recipe to use java.time api instead of @Temporal annotation

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -53,6 +53,7 @@ dependencies {
     testRuntimeOnly("jakarta.inject:jakarta.inject-api:2.0.1")
     testRuntimeOnly("jakarta.enterprise:jakarta.enterprise.cdi-api:4.1.0")
     testRuntimeOnly("org.projectlombok:lombok:latest.release")
+    testRuntimeOnly("jakarta.persistence:jakarta.persistence-api:3.2.0")
 }
 
 recipeDependencies {

--- a/src/main/java/org/openrewrite/quarkus/RefactorTemporalAnnotation.java
+++ b/src/main/java/org/openrewrite/quarkus/RefactorTemporalAnnotation.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2025 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.openrewrite.quarkus;
 
 import lombok.EqualsAndHashCode;

--- a/src/main/java/org/openrewrite/quarkus/RefactorTemporalAnnotation.java
+++ b/src/main/java/org/openrewrite/quarkus/RefactorTemporalAnnotation.java
@@ -1,0 +1,127 @@
+package org.openrewrite.quarkus;
+
+import lombok.EqualsAndHashCode;
+import lombok.Value;
+import org.jetbrains.annotations.NotNull;
+import org.jspecify.annotations.Nullable;
+import org.openrewrite.*;
+import org.openrewrite.java.ChangeType;
+import org.openrewrite.java.JavaIsoVisitor;
+import org.openrewrite.java.RemoveAnnotation;
+import org.openrewrite.java.TypeMatcher;
+import org.openrewrite.java.search.FindAnnotations;
+import org.openrewrite.java.search.UsesType;
+import org.openrewrite.java.tree.J;
+import org.openrewrite.java.tree.J.Annotation;
+import org.openrewrite.java.tree.J.FieldAccess;
+import org.openrewrite.java.tree.J.Identifier;
+
+import java.util.Objects;
+
+@Value
+@EqualsAndHashCode(callSuper = false)
+public class RefactorTemporalAnnotation extends Recipe {
+
+    private static final String TEMPORAL_ANNOTATION = "jakarta.persistence.Temporal";
+    private static final String ENTITY_ANNOTATION = "jakarta.persistence.Entity";
+    private static final String DATE_TYPE = "java.util.Date";
+    private static final String JAVA_TIME_LOCAL_DATE = "java.time.LocalDate";
+    private static final String JAVA_TIME_LOCAL_TIME = "java.time.LocalTime";
+    private static final String JAVA_TIME_OFFSETDATETIME = "java.time.OffsetDateTime";
+    private static final String JAVA_TIME_LOCAL_DATE_TIME = "java.time.LocalDateTime";
+
+    @Override
+    public String getDisplayName() {
+        return "Refactor @Temporal annotation java.util.Date fields to java.time API";
+    }
+
+    @Override
+    public String getDescription() {
+        return "Replace java.util.Date fields annotated with @Temporal "
+                + " with java.time.LocalDate, java.time.LocalTime, java.time.LocalDateTime or java.time.OffsetDateTime.";
+    }
+
+    @Option(displayName = "Use offsetDateTime",
+            description = "If `true` the recipe will use OffsetDateTime instead of LocalDateTime. Default `false`.",
+            required = false)
+    @Nullable
+    Boolean useOffsetDateTime;
+
+    @Override
+    public TreeVisitor<?, ExecutionContext> getVisitor() {
+        return Preconditions.check(
+                new UsesType<>(ENTITY_ANNOTATION, true),
+                new TemporalRefactorVisitor(useOffsetDateTime)
+        );
+    }
+
+    private static class TemporalRefactorVisitor extends JavaIsoVisitor<ExecutionContext> {
+
+        private static final TypeMatcher DATE_MATCHER = new TypeMatcher(DATE_TYPE);
+
+        private final Boolean useOffsetDT;
+
+        public TemporalRefactorVisitor(Boolean useOffsetDateTime) {
+            useOffsetDT = useOffsetDateTime;
+        }
+
+        @Override
+        public J.@NotNull VariableDeclarations visitVariableDeclarations(J.@NotNull VariableDeclarations multiVariable, @NotNull ExecutionContext ctx) {
+            J.VariableDeclarations decls = super.visitVariableDeclarations(multiVariable, ctx);
+
+            if (!DATE_MATCHER.matches(decls.getTypeExpression())) {
+                return decls;
+            }
+
+            Annotation temporalAnnotation = FindAnnotations.find(decls, TEMPORAL_ANNOTATION).stream()
+                    .findFirst()
+                    .orElse(null);
+
+            if (temporalAnnotation == null) {
+                return decls;
+            }
+
+            // Extract the enum constant (DATE or TIMESTAMP)
+            String newTypeToUse = Objects.requireNonNull(temporalAnnotation.getArguments()).stream()
+                    .findFirst()
+                    .map(arg -> {
+                        if (arg instanceof FieldAccess) {
+                            return getNewType(((FieldAccess) arg).getSimpleName());
+                        }
+                        if (arg instanceof Identifier) {
+                            return getNewType(((Identifier) arg).getSimpleName());
+                        }
+                        return null;
+                    })
+                    .orElse(null);
+
+            if (newTypeToUse == null) {
+                return decls;
+            }
+
+            doAfterVisit(new RemoveAnnotation(TEMPORAL_ANNOTATION).getVisitor());
+            decls = (J.VariableDeclarations) new ChangeType(DATE_TYPE, newTypeToUse, null).getVisitor().visitNonNull(decls, ctx);
+
+            maybeRemoveImport(DATE_TYPE);
+            maybeAddImport(newTypeToUse);
+            return decls;
+        }
+
+        private String getNewType(String temporalConstant) {
+            switch (temporalConstant) {
+                case "DATE":
+                    return JAVA_TIME_LOCAL_DATE;
+                case "TIME":
+                    return JAVA_TIME_LOCAL_TIME;
+                case "TIMESTAMP":
+                    if (Boolean.TRUE.equals(useOffsetDT)) {
+                        return JAVA_TIME_OFFSETDATETIME;
+                    } else {
+                        return JAVA_TIME_LOCAL_DATE_TIME;
+                    }
+                default:
+                    return null;
+            }
+        }
+    }
+}

--- a/src/test/java/org/openrewrite/quarkus/RefactorTemporalAnnotationTest.java
+++ b/src/test/java/org/openrewrite/quarkus/RefactorTemporalAnnotationTest.java
@@ -27,245 +27,245 @@ public class RefactorTemporalAnnotationTest implements RewriteTest {
     @Override
     public void defaults(RecipeSpec spec) {
         spec.recipes(new RefactorTemporalAnnotation(null))
-                .parser(JavaParser.fromJavaVersion()
-                        .classpath("jakarta.persistence-api"));
+          .parser(JavaParser.fromJavaVersion()
+            .classpath("jakarta.persistence-api"));
     }
 
     @Test
     void shouldRemoveTemporalAnnotationAndKeepOtherAnnotations() {
         rewriteRun(
-                //language=java
-                java(
-                        """
-                                package org.refactor.model;
+          //language=java
+          java(
+            """
+              package org.refactor.model;
 
-                                import jakarta.persistence.Column;
-                                import jakarta.persistence.Entity;
-                                import jakarta.persistence.Id;
-                                import jakarta.persistence.Table;
-                                import jakarta.persistence.Temporal;
+              import jakarta.persistence.Column;
+              import jakarta.persistence.Entity;
+              import jakarta.persistence.Id;
+              import jakarta.persistence.Table;
+              import jakarta.persistence.Temporal;
 
-                                import java.util.Date;
+              import java.util.Date;
 
-                                @Entity
-                                @Table(name = "rent_house")
-                                public class RentHouseEntity {
-                                    @Id
-                                    @Column(name = "rent_house_id")
-                                    private Long id;
+              @Entity
+              @Table(name = "rent_house")
+              public class RentHouseEntity {
+                  @Id
+                  @Column(name = "rent_house_id")
+                  private Long id;
 
-                                    @Column(name = "status")
-                                    private String status;
+                  @Column(name = "status")
+                  private String status;
 
-                                    @Column(name = "start_date")
-                                    @Temporal(TemporalType.DATE)
-                                    private Date startDate;
+                  @Column(name = "start_date")
+                  @Temporal(TemporalType.DATE)
+                  private Date startDate;
 
-                                    @Column(name = "end_date")
-                                    @Temporal(TemporalType.DATE)
-                                    private Date endDate;
+                  @Column(name = "end_date")
+                  @Temporal(TemporalType.DATE)
+                  private Date endDate;
 
-                                    @Column(name = "creation_date")
-                                    @Temporal(TemporalType.TIMESTAMP)
-                                    private Date creationDate;
-                                }
-                                """,
-                        """
-                                package org.refactor.model;
+                  @Column(name = "creation_date")
+                  @Temporal(TemporalType.TIMESTAMP)
+                  private Date creationDate;
+              }
+              """,
+            """
+              package org.refactor.model;
 
-                                import jakarta.persistence.Column;
-                                import jakarta.persistence.Entity;
-                                import jakarta.persistence.Id;
-                                import jakarta.persistence.Table;
+              import jakarta.persistence.Column;
+              import jakarta.persistence.Entity;
+              import jakarta.persistence.Id;
+              import jakarta.persistence.Table;
 
-                                import java.time.LocalDate;
-                                import java.time.LocalDateTime;
+              import java.time.LocalDate;
+              import java.time.LocalDateTime;
 
-                                @Entity
-                                @Table(name = "rent_house")
-                                public class RentHouseEntity {
-                                    @Id
-                                    @Column(name = "rent_house_id")
-                                    private Long id;
+              @Entity
+              @Table(name = "rent_house")
+              public class RentHouseEntity {
+                  @Id
+                  @Column(name = "rent_house_id")
+                  private Long id;
 
-                                    @Column(name = "status")
-                                    private String status;
+                  @Column(name = "status")
+                  private String status;
 
-                                    @Column(name = "start_date")
-                                    private LocalDate startDate;
+                  @Column(name = "start_date")
+                  private LocalDate startDate;
 
-                                    @Column(name = "end_date")
-                                    private LocalDate endDate;
+                  @Column(name = "end_date")
+                  private LocalDate endDate;
 
-                                    @Column(name = "creation_date")
-                                    private LocalDateTime creationDate;
-                                }
-                                """
-                )
+                  @Column(name = "creation_date")
+                  private LocalDateTime creationDate;
+              }
+              """
+          )
         );
     }
 
     @Test
     void shouldChangeNothing() {
         rewriteRun(
-                //language=java
-                java(
-                        """
-                                package org.refactor.model;
+          //language=java
+          java(
+            """
+              package org.refactor.model;
 
-                                import jakarta.persistence.Entity;
-                                import jakarta.persistence.Table;
-                                import java.util.Date;
+              import jakarta.persistence.Entity;
+              import jakarta.persistence.Table;
+              import java.util.Date;
 
-                                @Entity
-                                @Table(name = "some_entity")
-                                public class SomeEntity {
-                                    private Date createdOn;
-                                }
-                                """
-                )
+              @Entity
+              @Table(name = "some_entity")
+              public class SomeEntity {
+                  private Date createdOn;
+              }
+              """
+          )
         );
     }
 
     @Test
     void shouldRemoveTemporalAnnotationAndUseGoodType() {
         rewriteRun(
-                //language=java
-                java(
-                        """
-                                package org.refactor.model;
+          //language=java
+          java(
+            """
+              package org.refactor.model;
 
-                                import java.util.Date;
-                                import jakarta.persistence.Temporal;
-                                import jakarta.persistence.TemporalType;
-                                import jakarta.persistence.Entity;
-                                import jakarta.persistence.Table;
+              import java.util.Date;
+              import jakarta.persistence.Temporal;
+              import jakarta.persistence.TemporalType;
+              import jakarta.persistence.Entity;
+              import jakarta.persistence.Table;
 
-                                @Entity
-                                @Table(name = "some_entity")
-                                public class MultiTemporalEntity {
-                                    @Temporal(TemporalType.DATE)
-                                    private Date dateField;
+              @Entity
+              @Table(name = "some_entity")
+              public class MultiTemporalEntity {
+                  @Temporal(TemporalType.DATE)
+                  private Date dateField;
 
-                                    @Temporal(TemporalType.TIMESTAMP)
-                                    private Date timestampField;
+                  @Temporal(TemporalType.TIMESTAMP)
+                  private Date timestampField;
 
-                                    @Temporal(TemporalType.TIME)
-                                    private Date timeField;
-                                }
-                                """,
-                        """
-                                package org.refactor.model;
+                  @Temporal(TemporalType.TIME)
+                  private Date timeField;
+              }
+              """,
+            """
+              package org.refactor.model;
 
-                                import jakarta.persistence.Entity;
-                                import jakarta.persistence.Table;
+              import jakarta.persistence.Entity;
+              import jakarta.persistence.Table;
 
-                                import java.time.LocalDate;
-                                import java.time.LocalDateTime;
-                                import java.time.LocalTime;
+              import java.time.LocalDate;
+              import java.time.LocalDateTime;
+              import java.time.LocalTime;
 
-                                @Entity
-                                @Table(name = "some_entity")
-                                public class MultiTemporalEntity {
-                                    private LocalDate dateField;
+              @Entity
+              @Table(name = "some_entity")
+              public class MultiTemporalEntity {
+                  private LocalDate dateField;
 
-                                    private LocalDateTime timestampField;
+                  private LocalDateTime timestampField;
 
-                                    private LocalTime timeField;
-                                }
-                                """
-                )
+                  private LocalTime timeField;
+              }
+              """
+          )
         );
     }
 
     @Test
     void shouldRemoveTemporalAnnotationAndUseLocalDateTimeTypeWhenStaticImport() {
         rewriteRun(
-                //language=java
-                java(
-                        """
-                                package org.refactor.model;
+          //language=java
+          java(
+            """
+              package org.refactor.model;
 
-                                import java.util.Date;
-                                import static jakarta.persistence.TemporalType.DATE;
-                                import jakarta.persistence.Temporal;
-                                import jakarta.persistence.Entity;
-                                import jakarta.persistence.Table;
+              import java.util.Date;
+              import static jakarta.persistence.TemporalType.DATE;
+              import jakarta.persistence.Temporal;
+              import jakarta.persistence.Entity;
+              import jakarta.persistence.Table;
 
-                                @Entity
-                                @Table(name = "some_entity")
-                                public class SomeEntity {
-                                    @Temporal(DATE)
-                                    private Date dateField;
-                                }
-                                """,
-                        """
-                                package org.refactor.model;
+              @Entity
+              @Table(name = "some_entity")
+              public class SomeEntity {
+                  @Temporal(DATE)
+                  private Date dateField;
+              }
+              """,
+            """
+              package org.refactor.model;
 
-                                import jakarta.persistence.Entity;
-                                import jakarta.persistence.Table;
+              import jakarta.persistence.Entity;
+              import jakarta.persistence.Table;
 
-                                import java.time.LocalDate;
+              import java.time.LocalDate;
 
-                                @Entity
-                                @Table(name = "some_entity")
-                                public class SomeEntity {
-                                    private LocalDate dateField;
-                                }
-                                """
-                )
+              @Entity
+              @Table(name = "some_entity")
+              public class SomeEntity {
+                  private LocalDate dateField;
+              }
+              """
+          )
         );
     }
 
     @Test
     void shouldRemoveTemporalAnnotationWithOffsetDateTime() {
         rewriteRun(
-                spec -> spec.recipe(new RefactorTemporalAnnotation(true)),
-                //language=java
-                java(
-                        """
-                                package org.refactor.model;
+          spec -> spec.recipe(new RefactorTemporalAnnotation(true)),
+          //language=java
+          java(
+            """
+              package org.refactor.model;
 
-                                import java.util.Date;
-                                import jakarta.persistence.Temporal;
-                                import jakarta.persistence.TemporalType;
-                                import jakarta.persistence.Entity;
-                                import jakarta.persistence.Table;
+              import java.util.Date;
+              import jakarta.persistence.Temporal;
+              import jakarta.persistence.TemporalType;
+              import jakarta.persistence.Entity;
+              import jakarta.persistence.Table;
 
-                                @Entity
-                                @Table(name = "some_entity")
-                                public class MultiTemporalEntity {
-                                    @Temporal(TemporalType.DATE)
-                                    private Date dateField;
+              @Entity
+              @Table(name = "some_entity")
+              public class MultiTemporalEntity {
+                  @Temporal(TemporalType.DATE)
+                  private Date dateField;
 
-                                    @Temporal(TemporalType.TIMESTAMP)
-                                    private Date timestampField;
+                  @Temporal(TemporalType.TIMESTAMP)
+                  private Date timestampField;
 
-                                    @Temporal(TemporalType.TIME)
-                                    private Date timeField;
-                                }
-                                """,
-                        """
-                                package org.refactor.model;
+                  @Temporal(TemporalType.TIME)
+                  private Date timeField;
+              }
+              """,
+            """
+              package org.refactor.model;
 
-                                import jakarta.persistence.Entity;
-                                import jakarta.persistence.Table;
+              import jakarta.persistence.Entity;
+              import jakarta.persistence.Table;
 
-                                import java.time.LocalDate;
-                                import java.time.LocalTime;
-                                import java.time.OffsetDateTime;
+              import java.time.LocalDate;
+              import java.time.LocalTime;
+              import java.time.OffsetDateTime;
 
-                                @Entity
-                                @Table(name = "some_entity")
-                                public class MultiTemporalEntity {
-                                    private LocalDate dateField;
+              @Entity
+              @Table(name = "some_entity")
+              public class MultiTemporalEntity {
+                  private LocalDate dateField;
 
-                                    private OffsetDateTime timestampField;
+                  private OffsetDateTime timestampField;
 
-                                    private LocalTime timeField;
-                                }
-                                """
-                )
+                  private LocalTime timeField;
+              }
+              """
+          )
         );
     }
 }

--- a/src/test/java/org/openrewrite/quarkus/RefactorTemporalAnnotationTest.java
+++ b/src/test/java/org/openrewrite/quarkus/RefactorTemporalAnnotationTest.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2025 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.openrewrite.quarkus;
 
 import org.junit.jupiter.api.Test;

--- a/src/test/java/org/openrewrite/quarkus/RefactorTemporalAnnotationTest.java
+++ b/src/test/java/org/openrewrite/quarkus/RefactorTemporalAnnotationTest.java
@@ -1,0 +1,256 @@
+package org.openrewrite.quarkus;
+
+import org.junit.jupiter.api.Test;
+import org.openrewrite.java.JavaParser;
+import org.openrewrite.test.RecipeSpec;
+import org.openrewrite.test.RewriteTest;
+
+import static org.openrewrite.java.Assertions.java;
+
+public class RefactorTemporalAnnotationTest implements RewriteTest {
+
+    @Override
+    public void defaults(RecipeSpec spec) {
+        spec.recipes(new RefactorTemporalAnnotation(null))
+                .parser(JavaParser.fromJavaVersion()
+                        .classpath("jakarta.persistence-api"));
+    }
+
+    @Test
+    void shouldRemoveTemporalAnnotationAndKeepOtherAnnotations() {
+        rewriteRun(
+                //language=java
+                java(
+                        """
+                                package org.refactor.model;
+
+                                import jakarta.persistence.Column;
+                                import jakarta.persistence.Entity;
+                                import jakarta.persistence.Id;
+                                import jakarta.persistence.Table;
+                                import jakarta.persistence.Temporal;
+
+                                import java.util.Date;
+
+                                @Entity
+                                @Table(name = "rent_house")
+                                public class RentHouseEntity {
+                                    @Id
+                                    @Column(name = "rent_house_id")
+                                    private Long id;
+
+                                    @Column(name = "status")
+                                    private String status;
+
+                                    @Column(name = "start_date")
+                                    @Temporal(TemporalType.DATE)
+                                    private Date startDate;
+
+                                    @Column(name = "end_date")
+                                    @Temporal(TemporalType.DATE)
+                                    private Date endDate;
+
+                                    @Column(name = "creation_date")
+                                    @Temporal(TemporalType.TIMESTAMP)
+                                    private Date creationDate;
+                                }
+                                """,
+                        """
+                                package org.refactor.model;
+
+                                import jakarta.persistence.Column;
+                                import jakarta.persistence.Entity;
+                                import jakarta.persistence.Id;
+                                import jakarta.persistence.Table;
+
+                                import java.time.LocalDate;
+                                import java.time.LocalDateTime;
+
+                                @Entity
+                                @Table(name = "rent_house")
+                                public class RentHouseEntity {
+                                    @Id
+                                    @Column(name = "rent_house_id")
+                                    private Long id;
+
+                                    @Column(name = "status")
+                                    private String status;
+
+                                    @Column(name = "start_date")
+                                    private LocalDate startDate;
+
+                                    @Column(name = "end_date")
+                                    private LocalDate endDate;
+
+                                    @Column(name = "creation_date")
+                                    private LocalDateTime creationDate;
+                                }
+                                """
+                )
+        );
+    }
+
+    @Test
+    void shouldChangeNothing() {
+        rewriteRun(
+                //language=java
+                java(
+                        """
+                                package org.refactor.model;
+
+                                import jakarta.persistence.Entity;
+                                import jakarta.persistence.Table;
+                                import java.util.Date;
+
+                                @Entity
+                                @Table(name = "some_entity")
+                                public class SomeEntity {
+                                    private Date createdOn;
+                                }
+                                """
+                )
+        );
+    }
+
+    @Test
+    void shouldRemoveTemporalAnnotationAndUseGoodType() {
+        rewriteRun(
+                //language=java
+                java(
+                        """
+                                package org.refactor.model;
+
+                                import java.util.Date;
+                                import jakarta.persistence.Temporal;
+                                import jakarta.persistence.TemporalType;
+                                import jakarta.persistence.Entity;
+                                import jakarta.persistence.Table;
+
+                                @Entity
+                                @Table(name = "some_entity")
+                                public class MultiTemporalEntity {
+                                    @Temporal(TemporalType.DATE)
+                                    private Date dateField;
+
+                                    @Temporal(TemporalType.TIMESTAMP)
+                                    private Date timestampField;
+
+                                    @Temporal(TemporalType.TIME)
+                                    private Date timeField;
+                                }
+                                """,
+                        """
+                                package org.refactor.model;
+
+                                import jakarta.persistence.Entity;
+                                import jakarta.persistence.Table;
+
+                                import java.time.LocalDate;
+                                import java.time.LocalDateTime;
+                                import java.time.LocalTime;
+
+                                @Entity
+                                @Table(name = "some_entity")
+                                public class MultiTemporalEntity {
+                                    private LocalDate dateField;
+
+                                    private LocalDateTime timestampField;
+
+                                    private LocalTime timeField;
+                                }
+                                """
+                )
+        );
+    }
+
+    @Test
+    void shouldRemoveTemporalAnnotationAndUseLocalDateTimeTypeWhenStaticImport() {
+        rewriteRun(
+                //language=java
+                java(
+                        """
+                                package org.refactor.model;
+
+                                import java.util.Date;
+                                import static jakarta.persistence.TemporalType.DATE;
+                                import jakarta.persistence.Temporal;
+                                import jakarta.persistence.Entity;
+                                import jakarta.persistence.Table;
+
+                                @Entity
+                                @Table(name = "some_entity")
+                                public class SomeEntity {
+                                    @Temporal(DATE)
+                                    private Date dateField;
+                                }
+                                """,
+                        """
+                                package org.refactor.model;
+
+                                import jakarta.persistence.Entity;
+                                import jakarta.persistence.Table;
+
+                                import java.time.LocalDate;
+
+                                @Entity
+                                @Table(name = "some_entity")
+                                public class SomeEntity {
+                                    private LocalDate dateField;
+                                }
+                                """
+                )
+        );
+    }
+
+    @Test
+    void shouldRemoveTemporalAnnotationWithOffsetDateTime() {
+        rewriteRun(
+                spec -> spec.recipe(new RefactorTemporalAnnotation(true)),
+                //language=java
+                java(
+                        """
+                                package org.refactor.model;
+
+                                import java.util.Date;
+                                import jakarta.persistence.Temporal;
+                                import jakarta.persistence.TemporalType;
+                                import jakarta.persistence.Entity;
+                                import jakarta.persistence.Table;
+
+                                @Entity
+                                @Table(name = "some_entity")
+                                public class MultiTemporalEntity {
+                                    @Temporal(TemporalType.DATE)
+                                    private Date dateField;
+
+                                    @Temporal(TemporalType.TIMESTAMP)
+                                    private Date timestampField;
+
+                                    @Temporal(TemporalType.TIME)
+                                    private Date timeField;
+                                }
+                                """,
+                        """
+                                package org.refactor.model;
+
+                                import jakarta.persistence.Entity;
+                                import jakarta.persistence.Table;
+
+                                import java.time.LocalDate;
+                                import java.time.LocalTime;
+                                import java.time.OffsetDateTime;
+
+                                @Entity
+                                @Table(name = "some_entity")
+                                public class MultiTemporalEntity {
+                                    private LocalDate dateField;
+
+                                    private OffsetDateTime timestampField;
+
+                                    private LocalTime timeField;
+                                }
+                                """
+                )
+        );
+    }
+}


### PR DESCRIPTION
## What's changed?
Add a new recipe to remove @Temporal annotation when using java.util.Date and convert type with java.time api

## What's your motivation?
Prefer using java.time api in persistence layer

## Anything in particular you'd like reviewers to focus on?
Maybe this recipe can be used not only in quarkus context

## Anyone you would like to review specifically?
@timtebeek 

## Have you considered any alternatives or workarounds?
Yes, looking for existing recipe but not found

## Any additional context
no

### Checklist
- [ x] I've added unit tests to cover both positive and negative cases
- [ x] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [ x] I've used the IntelliJ IDEA auto-formatter on affected files
