### PR TITLE
JavaEE migration tests no longer need 2 cycles

### DIFF
--- a/src/test/java/org/openrewrite/quarkus/migrate/javaee/JavaEEtoQuarkus2MavenDependenciesMigrationTest.java
+++ b/src/test/java/org/openrewrite/quarkus/migrate/javaee/JavaEEtoQuarkus2MavenDependenciesMigrationTest.java
@@ -32,7 +32,6 @@ class JavaEEtoQuarkus2MavenDependenciesMigrationTest implements RewriteTest {
     @Test
     void convertJavaEEToQuarkusDependencies1() {
         rewriteRun(
-          spec -> spec.expectedCyclesThatMakeChanges(2),
           // language=xml
           pomXml(
             """
@@ -213,7 +212,6 @@ class JavaEEtoQuarkus2MavenDependenciesMigrationTest implements RewriteTest {
     @Test
     void convertJavaEEToQuarkusDependencies2() {
         rewriteRun(
-          spec -> spec.expectedCyclesThatMakeChanges(2),
           // language=xml
           pomXml(
             """

--- a/src/test/java/org/openrewrite/quarkus/migrate/javaee/JavaEEtoQuarkus2MavenDependenciesMigrationTest.java
+++ b/src/test/java/org/openrewrite/quarkus/migrate/javaee/JavaEEtoQuarkus2MavenDependenciesMigrationTest.java
@@ -212,6 +212,7 @@ class JavaEEtoQuarkus2MavenDependenciesMigrationTest implements RewriteTest {
     @Test
     void convertJavaEEToQuarkusDependencies2() {
         rewriteRun(
+          spec -> spec.expectedCyclesThatMakeChanges(2),
           // language=xml
           pomXml(
             """
@@ -303,18 +304,9 @@ class JavaEEtoQuarkus2MavenDependenciesMigrationTest implements RewriteTest {
 
                 <dependencies>
                   <dependency>
-                    <groupId>io.quarkus</groupId>
-                    <artifactId>quarkus-junit5</artifactId>
-                    <scope>test</scope>
-                  </dependency>
-                  <dependency>
-                    <groupId>io.rest-assured</groupId>
-                    <artifactId>rest-assured</artifactId>
-                    <scope>test</scope>
-                  </dependency>
-                  <dependency>
-                    <groupId>org.apache.commons</groupId>
-                    <artifactId>commons-lang3</artifactId>
+                    <groupId>com.fasterxml.jackson.jaxrs</groupId>
+                    <artifactId>jackson-jaxrs-json-provider</artifactId>
+                    <version>2.12.3</version>
                   </dependency>
                   <dependency>
                     <groupId>commons-beanutils</groupId>
@@ -346,9 +338,18 @@ class JavaEEtoQuarkus2MavenDependenciesMigrationTest implements RewriteTest {
                     <artifactId>quarkus-undertow</artifactId>
                   </dependency>
                   <dependency>
-                    <groupId>com.fasterxml.jackson.jaxrs</groupId>
-                    <artifactId>jackson-jaxrs-json-provider</artifactId>
-                    <version>2.12.3</version>
+                    <groupId>org.apache.commons</groupId>
+                    <artifactId>commons-lang3</artifactId>
+                  </dependency>
+                  <dependency>
+                    <groupId>io.quarkus</groupId>
+                    <artifactId>quarkus-junit5</artifactId>
+                    <scope>test</scope>
+                  </dependency>
+                  <dependency>
+                    <groupId>io.rest-assured</groupId>
+                    <artifactId>rest-assured</artifactId>
+                    <scope>test</scope>
                   </dependency>
                   <dependency>
                     <groupId>junit</groupId>


### PR DESCRIPTION
- The addition of `SortDependencies` to Maven `BestPractices` in openrewrite/rewrite#7352 means the `JavaEEtoQuarkus2Migration` recipe now completes in a single cycle. The explicit `expectedCyclesThatMakeChanges(2)` overrides in both `convertJavaEEToQuarkusDependencies` tests cause a test framework assertion failure since the recipe stabilizes after cycle 1.

Removed the cycle override so the tests use the default expectation of 1 cycle.